### PR TITLE
Add path position overlays and port over unittests from VG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,23 +2,27 @@ SRC_DIR:=src
 OBJ_DIR:=obj
 INC_DIR:=include
 LIB_DIR:=lib
+BIN_DIR:=bin
 
 INSTALL_PREFIX?=/usr/local
 INSTALL_LIB_DIR=$(INSTALL_PREFIX)/lib
 INSTALL_INC_DIR=$(INSTALL_PREFIX)/include
 
-OBJS:=$(OBJ_DIR)/eades_algorithm.o $(OBJ_DIR)/hash_graph.o $(OBJ_DIR)/is_single_stranded.o $(OBJ_DIR)/node.o $(OBJ_DIR)/odgi.o $(OBJ_DIR)/packed_graph.o $(OBJ_DIR)/packed_structs.o $(OBJ_DIR)/split_strand_graph.o $(OBJ_DIR)/utility.o
+OBJS:=$(OBJ_DIR)/eades_algorithm.o $(OBJ_DIR)/hash_graph.o $(OBJ_DIR)/is_single_stranded.o $(OBJ_DIR)/node.o $(OBJ_DIR)/odgi.o $(OBJ_DIR)/packed_graph.o $(OBJ_DIR)/packed_structs.o $(OBJ_DIR)/path_position_overlays.o $(OBJ_DIR)/split_strand_graph.o $(OBJ_DIR)/utility.o
 
 CXXFLAGS :=-O3 -Werror=return-type -std=c++14 -ggdb -g -msse4.2 -I$(INC_DIR) $(CXXFLAGS)
 
 .PHONY: .pre-build all clean install
 
-all:
-	make $(LIB_DIR)/libbdsg.a
+all: $(LIB_DIR)/libbdsg.a
+
+test: all $(BIN_DIR)/test_libbdsg
+	./$(BIN_DIR)/test_libbdsg
 
 .pre-build:
 	@if [ ! -d $(LIB_DIR) ]; then mkdir -p $(LIB_DIR); fi
 	@if [ ! -d $(OBJ_DIR) ]; then mkdir -p $(OBJ_DIR); fi
+	@if [ ! -d $(OBJ_DIR) ]; then mkdir -p $(BIN_DIR); fi
 
 # run .pre-build before we make anything at all.
 -include .pre-build
@@ -55,7 +59,11 @@ $(OBJ_DIR)/utility.o: $(SRC_DIR)/utility.cpp $(INC_DIR)/bdsg/utility.hpp
 
 $(LIB_DIR)/libbdsg.a: $(OBJS)
 	rm -f $@
-	ar rs $@ $(OBJ_DIR)/*.o
+	ar rs $@ $(OBJS)
+
+$(BIN_DIR)/test_libbdsg: $(LIB_DIR)/libbdsg.a $(SRC_DIR)/test_libbdsg.cpp 
+	$(CXX) $(CXXFLAGS) -L $(LIB_DIR) -lbdsg -lsdsl -lhandlegraph $(SRC_DIR)/test_libbdsg.cpp -o $(BIN_DIR)/test_libbdsg
+	chmod +x $(BIN_DIR)/test_libbdsg
 
 install: $(LIB_DIR)/libbdsg.a
 	mkdir -p $(INSTALL_LIB_DIR)

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ $(OBJ_DIR)/packed_graph.o: $(SRC_DIR)/packed_graph.cpp $(INC_DIR)/bdsg/packed_gr
 $(OBJ_DIR)/packed_structs.o: $(SRC_DIR)/packed_structs.cpp $(INC_DIR)/bdsg/packed_structs.hpp
 	$(CXX) $(CXXFLAGS) -c $(SRC_DIR)/packed_structs.cpp -o $(OBJ_DIR)/packed_structs.o 
 
+$(OBJ_DIR)/path_position_overlays.o: $(SRC_DIR)/path_position_overlays.cpp $(INC_DIR)/bdsg/path_position_overlays.hpp
+	$(CXX) $(CXXFLAGS) -c $(SRC_DIR)/path_position_overlays.cpp -o $(OBJ_DIR)/path_position_overlays.o 
+
 $(OBJ_DIR)/split_strand_graph.o: $(SRC_DIR)/split_strand_graph.cpp $(INC_DIR)/bdsg/split_strand_graph.hpp
 	$(CXX) $(CXXFLAGS) -c $(SRC_DIR)/split_strand_graph.cpp -o $(OBJ_DIR)/split_strand_graph.o 
 

--- a/Makefile
+++ b/Makefile
@@ -74,3 +74,5 @@ install: $(LIB_DIR)/libbdsg.a
 clean:
 	rm -r $(OBJ_DIR)
 	rm -r $(LIB_DIR)
+	rm -r $(BIN_DIR)
+

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test: all $(BIN_DIR)/test_libbdsg
 .pre-build:
 	@if [ ! -d $(LIB_DIR) ]; then mkdir -p $(LIB_DIR); fi
 	@if [ ! -d $(OBJ_DIR) ]; then mkdir -p $(OBJ_DIR); fi
-	@if [ ! -d $(OBJ_DIR) ]; then mkdir -p $(BIN_DIR); fi
+	@if [ ! -d $(BIN_DIR) ]; then mkdir -p $(BIN_DIR); fi
 
 # run .pre-build before we make anything at all.
 -include .pre-build

--- a/include/bdsg/packed_graph.hpp
+++ b/include/bdsg/packed_graph.hpp
@@ -89,7 +89,7 @@ public:
     /// Returns a substring of a handle's sequence, in the orientation of the
     /// handle. If the indicated substring would extend beyond the end of the
     /// handle's sequence, the return value is truncated to the sequence's end.
-    virtual std::string get_subsequence(const handle_t& handle, size_t index, size_t size) const;
+    std::string get_subsequence(const handle_t& handle, size_t index, size_t size) const;
     
     /// Return the number of nodes in the graph
     size_t get_node_count(void) const;

--- a/include/bdsg/path_position_overlays.hpp
+++ b/include/bdsg/path_position_overlays.hpp
@@ -1,0 +1,387 @@
+//
+//  path_position_overlays.hpp
+//  
+//  Contains generic overlays for MutablePathDeletableHandleGraph's that add the
+//  PathPositionHandleGraph interface methods for querying steps by base-pair
+//  position.
+//
+
+#ifndef BDSG_PATH_POSITION_OVERLAYS_HPP_INCLUDED
+#define BDSG_PATH_POSITION_OVERLAYS_HPP_INCLUDED
+
+#include <unordered_map>
+#include <map>
+
+#include <handlegraph/mutable_path_deletable_handle_graph.hpp>
+#include <handlegraph/path_position_handle_graph.hpp>
+#include <handlegraph/expanding_overlay_graph.hpp>
+
+namespace bdsg {
+    
+using namespace std;
+using namespace handlegraph;
+
+/*
+ * An overlay that adds the PathPositionHandleGraph interface to a PathHandleGraph
+ * by augmenting it with relatively simple data structures.
+ *
+ * To also provide mutable methods, see MutablePositionOverlay below.
+ */
+class PositionOverlay : public PathPositionHandleGraph, public ExpandingOverlayGraph {
+        
+public:
+    
+    PositionOverlay(PathHandleGraph* graph);
+    PositionOverlay();
+    ~PositionOverlay();
+
+    ////////////////////////////////////////////////////////////////////////////
+    // HandleGraph interface
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Method to check if a node exists by ID
+    bool has_node(nid_t node_id) const;
+    
+    /// Look up the handle for the node with the given ID in the given orientation
+    handle_t get_handle(const nid_t& node_id, bool is_reverse = false) const;
+    
+    /// Get the ID from a handle
+    nid_t get_id(const handle_t& handle) const;
+    
+    /// Get the orientation of a handle
+    bool get_is_reverse(const handle_t& handle) const;
+    
+    /// Invert the orientation of a handle (potentially without getting its ID)
+    handle_t flip(const handle_t& handle) const;
+    
+    /// Get the length of a node
+    size_t get_length(const handle_t& handle) const;
+    
+    /// Get the sequence of a node, presented in the handle's local forward orientation.
+    string get_sequence(const handle_t& handle) const;
+    
+private:
+    
+    /// Loop over all the handles to next/previous (right/left) nodes. Passes
+    /// them to a callback which returns false to stop iterating and true to
+    /// continue. Returns true if we finished and false if we stopped early.
+    bool follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const;
+    
+    /// Loop over all the nodes in the graph in their local forward
+    /// orientations, in their internal stored order. Stop if the iteratee
+    /// returns false. Can be told to run in parallel, in which case stopping
+    /// after a false return value is on a best-effort basis and iteration
+    /// order is not defined.
+    bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
+    
+public:
+    
+    /// Get the number of edges on the right (go_left = false) or left (go_left
+    /// = true) side of the given handle. The default implementation is O(n) in
+    /// the number of edges returned, but graph implementations that track this
+    /// information more efficiently can override this method.
+    size_t get_degree(const handle_t& handle, bool go_left) const;
+    
+    /// Returns true if there is an edge that allows traversal from the left
+    /// handle to the right handle. By default O(n) in the number of edges
+    /// on left, but can be overridden with more efficient implementations.
+    bool has_edge(const handle_t& left, const handle_t& right) const;
+    
+    /// Returns one base of a handle's sequence, in the orientation of the
+    /// handle.
+    char get_base(const handle_t& handle, size_t index) const;
+    
+    /// Returns a substring of a handle's sequence, in the orientation of the
+    /// handle. If the indicated substring would extend beyond the end of the
+    /// handle's sequence, the return value is truncated to the sequence's end.
+    std::string get_subsequence(const handle_t& handle, size_t index, size_t size) const;
+    
+    /// Return the number of nodes in the graph
+    size_t get_node_count(void) const;
+    
+    /// Return the smallest ID in the graph, or some smaller number if the
+    /// smallest ID is unavailable. Return value is unspecified if the graph is empty.
+    nid_t min_node_id(void) const;
+    
+    /// Return the largest ID in the graph, or some larger number if the
+    /// largest ID is unavailable. Return value is unspecified if the graph is empty.
+    nid_t max_node_id(void) const;
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Path handle interface
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Returns the number of paths stored in the graph
+    size_t get_path_count() const;
+
+    /// Determine if a path name exists and is legal to get a path handle for.
+    bool has_path(const std::string& path_name) const;
+
+    /// Look up the path handle for the given path name.
+    /// The path with that name must exist.
+    path_handle_t get_path_handle(const std::string& path_name) const;
+
+    /// Look up the name of a path from a handle to it
+    string get_path_name(const path_handle_t& path_handle) const;
+    
+    /// Look up whether a path is circular
+    bool get_is_circular(const path_handle_t& path_handle) const;
+
+    /// Returns the number of node steps in the path
+    size_t get_step_count(const path_handle_t& path_handle) const;
+
+    /// Get a node handle (node ID and orientation) from a handle to an step on a path
+    handle_t get_handle_of_step(const step_handle_t& step_handle) const;
+
+    /// Get a handle to the first step, or in a circular path to an arbitrary step
+    /// considered "first". If the path is empty, returns the past-the-last step
+    /// returned by path_end.
+    step_handle_t path_begin(const path_handle_t& path_handle) const;
+    
+    /// Get a handle to a fictitious position past the end of a path. This position is
+    /// return by get_next_step for the final step in a path in a non-circular path.
+    /// Note that get_next_step will *NEVER* return this value for a circular path.
+    step_handle_t path_end(const path_handle_t& path_handle) const;
+    
+    /// Get a handle to the last step, which will be an arbitrary step in a circular path that
+    /// we consider "last" based on our construction of the path. If the path is empty
+    /// then the implementation must return the same value as path_front_end().
+    step_handle_t path_back(const path_handle_t& path_handle) const;
+    
+    /// Get a handle to a fictitious position before the beginning of a path. This position is
+    /// return by get_previous_step for the first step in a path in a non-circular path.
+    /// Note: get_previous_step will *NEVER* return this value for a circular path.
+    step_handle_t path_front_end(const path_handle_t& path_handle) const;
+    
+    /// Returns true if the step is not the last step in a non-circular path.
+    bool has_next_step(const step_handle_t& step_handle) const;
+    
+    /// Returns true if the step is not the first step in a non-circular path.
+    bool has_previous_step(const step_handle_t& step_handle) const;
+    
+    /// Returns a handle to the next step on the path. If the given step is the final step
+    /// of a non-circular path, returns the past-the-last step that is also returned by
+    /// path_end. In a circular path, the "last" step will loop around to the "first" (i.e.
+    /// the one returned by path_begin).
+    /// Note: to iterate over each step one time, even in a circular path, consider
+    /// for_each_step_in_path.
+    step_handle_t get_next_step(const step_handle_t& step_handle) const;
+    
+    /// Returns a handle to the previous step on the path. If the given step is the first
+    /// step of a non-circular path, this method has undefined behavior. In a circular path,
+    /// it will loop around from the "first" step (i.e. the one returned by path_begin) to
+    /// the "last" step.
+    /// Note: to iterate over each step one time, even in a circular path, consider
+    /// for_each_step_in_path.
+    step_handle_t get_previous_step(const step_handle_t& step_handle) const;
+    
+    /// Returns a handle to the path that an step is on
+    path_handle_t get_path_handle_of_step(const step_handle_t& step_handle) const;
+    
+private:
+    /// Execute a function on each path in the graph
+    bool for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const;
+    
+    /// Calls the given function for each step of the given handle on a path.
+    bool for_each_step_on_handle_impl(const handle_t& handle,
+                                      const function<bool(const step_handle_t&)>& iteratee) const;
+    
+public:
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Path position interface
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Returns the length of a path measured in bases of sequence.
+    size_t get_path_length(const path_handle_t& path_handle) const;
+    
+    /// Returns the position along the path of the beginning of this step measured in
+    /// bases of sequence. In a circular path, positions start at the step returned by
+    /// path_begin().
+    size_t get_position_of_step(const step_handle_t& step) const;
+    
+    /// Returns the step at this position, measured in bases of sequence starting at
+    /// the step returned by path_begin(). If the position is past the end of the
+    /// path, returns path_end().
+    step_handle_t get_step_at_position(const path_handle_t& path,
+                                               const size_t& position) const;
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Expanding overlay interface
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /**
+     * Returns the handle in the underlying graph that corresponds to a handle in the
+     * overlay
+     */
+    handle_t get_underlying_handle(const handle_t& handle) const;
+    
+protected:
+    
+    /// Construct the index over path positions
+    void index_path_positions();
+    
+    /// The graph we're overlaying
+    PathHandleGraph* graph = nullptr;
+    
+    /// The "zero-point" of the offsets
+    /// TODO: really only needed for the mutable inheritor
+    unordered_map<path_handle_t, int64_t> min_path_offset;
+    
+    /// Index of step by position
+    unordered_map<path_handle_t, map<int64_t, step_handle_t>> step_by_position;
+    
+    /// Index of position by step
+    unordered_map<step_handle_t, int64_t> offset_by_step;
+    
+    /// Getter for graph
+    inline const PathHandleGraph* get_graph() const {
+        return graph;
+    }
+};
+
+    
+/*
+ * An overlay that adds the PathPositionHandleGraph interface to a MutablePathDeletableHandleGraph
+ * by augmenting it with relatively simple data structures.
+ */
+class MutablePositionOverlay : public PositionOverlay, public MutablePathDeletableHandleGraph {
+    
+public:
+    
+    MutablePositionOverlay(MutablePathDeletableHandleGraph* graph);
+    MutablePositionOverlay();
+    ~MutablePositionOverlay();
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // MutableHandleGraph interface
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Create a new node with the given sequence and return the handle.
+    handle_t create_handle(const std::string& sequence);
+    
+    /// Create a new node with the given id and sequence, then return the handle.
+    handle_t create_handle(const std::string& sequence, const nid_t& id);
+    
+    /// Remove the node belonging to the given handle and all of its edges.
+    /// Does not update any stored paths.
+    /// Invalidates the destroyed handle.
+    /// May be called during serial for_each_handle iteration **ONLY** on the node being iterated.
+    /// May **NOT** be called during parallel for_each_handle iteration.
+    /// May **NOT** be called on the node from which edges are being followed during follow_edges.
+    void destroy_handle(const handle_t& handle);
+    
+    /// Create an edge connecting the given handles in the given order and orientations.
+    /// Ignores existing edges.
+    void create_edge(const handle_t& left, const handle_t& right);
+    
+    /// Remove the edge connecting the given handles in the given order and orientations.
+    /// Ignores nonexistent edges.
+    /// Does not update any stored paths.
+    void destroy_edge(const handle_t& left, const handle_t& right);
+    
+    /// Remove all nodes and edges. Does not update any stored paths.
+    void clear(void);
+    
+    /// Alter the node that the given handle corresponds to so the orientation
+    /// indicated by the handle becomes the node's local forward orientation.
+    /// Rewrites all edges pointing to the node and the node's sequence to
+    /// reflect this. Invalidates all handles to the node (including the one
+    /// passed). Returns a new, valid handle to the node in its new forward
+    /// orientation. Note that it is possible for the node's ID to change.
+    /// Does not update any stored paths. May change the ordering of the underlying
+    /// graph.
+    handle_t apply_orientation(const handle_t& handle);
+    
+    /// Split a handle's underlying node at the given offsets in the handle's
+    /// orientation. Returns all of the handles to the parts. Other handles to
+    /// the node being split may be invalidated. The split pieces stay in the
+    /// same local forward orientation as the original node, but the returned
+    /// handles come in the order and orientation appropriate for the handle
+    /// passed in.
+    /// Updates stored paths.
+    vector<handle_t> divide_handle(const handle_t& handle, const std::vector<size_t>& offsets);
+    
+    /// Adjust the representation of the graph in memory to improve performance.
+    /// Optionally, allow the node IDs to be reassigned to further improve
+    /// performance.
+    /// Note: Ideally, this method is called one time once there is expected to be
+    /// few graph modifications in the future.
+    void optimize(bool allow_id_reassignment = true);
+    
+    /// Reorder the graph's internal structure to match that given.
+    /// This sets the order that is used for iteration in functions like for_each_handle.
+    /// Optionally compact the id space of the graph to match the ordering, from 1->|ordering|.
+    /// This may be a no-op in the case of graph implementations that do not have any mechanism to maintain an ordering.
+    void apply_ordering(const vector<handle_t>& order, bool compact_ids = false);
+    
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // MutablePathHandleGraph interface
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /**
+     * Destroy the given path. Invalidates handles to the path and its node steps.
+     */
+    void destroy_path(const path_handle_t& path);
+    
+    /**
+     * Create a path with the given name. The caller must ensure that no path
+     * with the given name exists already, or the behavior is undefined.
+     * Returns a handle to the created empty path. Handles to other paths must
+     * remain valid.
+     */
+    path_handle_t create_path_handle(const string& name, bool is_circular = false);
+    
+    /**
+     * Append a visit to a node to the given path. Returns a handle to the new
+     * final step on the path which is appended. Handles to prior
+     * steps on the path, and to other paths, must remain valid.
+     */
+    step_handle_t append_step(const path_handle_t& path, const handle_t& to_append);
+    
+    /**
+     * Prepend a visit to a node to the given path. Returns a handle to the new
+     * first step on the path which is appended. If the path is cirular, the new
+     * step is placed between the steps considered "last" and "first" by the
+     * method path_begin. Handles to later steps on the path, and to other paths,
+     * must remain valid.
+     */
+    step_handle_t prepend_step(const path_handle_t& path, const handle_t& to_prepend);
+    
+    /// WARNING: online path position indexing is inefficient for this method.
+    /**
+     * Delete a segment of a path and rewrite it as some other sequence of steps. Returns a pair
+     * of step_handle_t's that indicate the range of the new segment in the path. The segment to
+     * delete should be designated by the first and the past-the-last step handle.  If the step
+     * that is returned by path_begin is deleted, path_begin will now return the first step from
+     * the new segment or, in the case that the new segment is empty, segment_end.
+     */
+    pair<step_handle_t, step_handle_t> rewrite_segment(const step_handle_t& segment_begin,
+                                                       const step_handle_t& segment_end,
+                                                       const vector<handle_t>& new_segment);
+    
+    /**
+     * Make a path circular or non-circular. If the path is becoming circular, the
+     * last step is joined to the first step. If the path is becoming linear, the
+     * step considered "last" is unjoined from the step considered "first" according
+     * to the method path_begin.
+     */
+    void set_circularity(const path_handle_t& path, bool circular);
+    
+private:
+    
+    /// Clear indexes and rebuild them
+    void reindex_path_position();
+    
+    /// Override the get_graph from the PositionOverlay with a mutable cast (which must be
+    /// valid if the constructor was valid)
+    inline MutablePathDeletableHandleGraph* get_graph() {
+        return (MutablePathDeletableHandleGraph*) graph;
+    }
+    
+}
+    
+}
+
+#endif

--- a/include/bdsg/path_position_overlays.hpp
+++ b/include/bdsg/path_position_overlays.hpp
@@ -1,7 +1,7 @@
 //
 //  path_position_overlays.hpp
 //  
-//  Contains generic overlays for MutablePathDeletableHandleGraph's that add the
+//  Contains generic overlays for PathHandleGraph's that add the
 //  PathPositionHandleGraph interface methods for querying steps by base-pair
 //  position.
 //
@@ -374,11 +374,14 @@ private:
     /// Clear indexes and rebuild them
     void reindex_path_position();
     
+    /// Indexes all of the steps contiguous with this one that are missing
+    /// from the offset indexes (e.g. after an edit operation). Does nothing
+    /// if the step is already indexed.
+    void reindex_contiguous_segment(const step_handle_t& step);
+    
     /// Override the get_graph from the PositionOverlay with a mutable cast (which must be
     /// valid if the constructor was valid)
-    inline MutablePathDeletableHandleGraph* get_graph() {
-        return reinterpret_cast<MutablePathDeletableHandleGraph*>(graph);
-    }
+    MutablePathDeletableHandleGraph* get_graph();
     
 };
     

--- a/include/bdsg/path_position_overlays.hpp
+++ b/include/bdsg/path_position_overlays.hpp
@@ -377,10 +377,10 @@ private:
     /// Override the get_graph from the PositionOverlay with a mutable cast (which must be
     /// valid if the constructor was valid)
     inline MutablePathDeletableHandleGraph* get_graph() {
-        return (MutablePathDeletableHandleGraph*) graph;
+        return reinterpret_cast<MutablePathDeletableHandleGraph*>(graph);
     }
     
-}
+};
     
 }
 

--- a/src/path_position_overlays.cpp
+++ b/src/path_position_overlays.cpp
@@ -1,0 +1,426 @@
+#include "bdsg/path_position_overlays.hpp"
+
+namespace bdsg {
+
+    PositionOverlay::PositionOverlay(PathHandleGraph* graph) : graph(graph) {
+        index_path_positions();
+    }
+
+    PositionOverlay::PositionOverlay() {
+        
+    }
+    
+    PositionOverlay::~PositionOverlay() {
+        
+    }
+    
+    bool PositionOverlay::has_node(nid_t node_id) const {
+        return get_graph()->has_node(node_id);
+    }
+    
+    handle_t PositionOverlay::get_handle(const nid_t& node_id, bool is_reverse) const {
+        return get_graph()->get_handle(node_id, is_reverse);
+    }
+    
+    nid_t PositionOverlay::get_id(const handle_t& handle) const {
+        return get_graph()->get_id(handle);
+    }
+    
+    bool PositionOverlay::get_is_reverse(const handle_t& handle) const {
+        return get_graph()->;
+    }
+    
+    handle_t PositionOverlay::flip(const handle_t& handle) const {
+        return get_graph()->flip(handle);
+    }
+    
+    size_t PositionOverlay::get_length(const handle_t& handle) const {
+        return get_graph()->get_length(handle);
+    }
+    
+    string PositionOverlay::get_sequence(const handle_t& handle) const {
+        return get_graph()->get_sequence(handle);
+    }
+    
+    bool PositionOverlay::follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const {
+        return get_graph()->follow_edges(handle, go_left, iteratee);
+    }
+    
+    bool PositionOverlay::for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel) const {
+        return get_graph()->for_each_handle(iteratee, parallel);
+    }
+    
+    size_t PositionOverlay::get_degree(const handle_t& handle, bool go_left) const {
+        return get_graph()->get_degree(handle, go_left);
+    }
+    
+    bool PositionOverlay::has_edge(const handle_t& left, const handle_t& right) const {
+        return get_graph()->has_edge(left, right);
+    }
+    
+    char PositionOverlay::get_base(const handle_t& handle, size_t index) const {
+        return get_graph()->get_base(handle, index);
+    }
+    
+    std::string PositionOverlay::get_subsequence(const handle_t& handle, size_t index, size_t size) const {
+        return get_graph()->get_subsequence(handle, index, size);
+    }
+    
+    size_t PositionOverlay::get_node_count(void) const {
+        return get_graph()->get_node_count();
+    }
+    
+    nid_t PositionOverlay::min_node_id(void) const {
+        return get_graph()->min_node_id();
+    }
+    
+    nid_t PositionOverlay::max_node_id(void) const {
+        return get_graph()->max_node_id();
+    }
+    
+    size_t PositionOverlay::get_path_count() const {
+        return get_graph()->get_path_count();
+    }
+    
+    bool PositionOverlay::has_path(const std::string& path_name) const {
+        return get_graph()->has_path(path_name);
+    }
+    
+    path_handle_t PositionOverlay::get_path_handle(const std::string& path_name) const {
+        return get_graph()->get_path_handle(path_name);
+    }
+    
+    string PositionOverlay::get_path_name(const path_handle_t& path_handle) const {
+        return get_graph()->get_path_name(path_handle);
+    }
+    
+    bool PositionOverlay::get_is_circular(const path_handle_t& path_handle) const {
+        return get_graph()->get_is_circular(path_handle);
+    }
+    
+    size_t PositionOverlay::get_step_count(const path_handle_t& path_handle) const {
+        return get_graph()->get_step_count(path_handle);
+    }
+    
+    handle_t PositionOverlay::get_handle_of_step(const step_handle_t& step_handle) const {
+        return get_graph()->get_handle_of_step(step_handle);
+    }
+    
+    step_handle_t PositionOverlay::path_begin(const path_handle_t& path_handle) const {
+        return get_graph()->path_begin(path_handle);
+    }
+    
+    step_handle_t PositionOverlay::path_end(const path_handle_t& path_handle) const {
+        return get_graph()->path_end(path_handle);
+    }
+    
+    step_handle_t PositionOverlay::path_back(const path_handle_t& path_handle) const {
+        return get_graph()->path_back(path_handle);
+    }
+    
+    step_handle_t PositionOverlay::path_front_end(const path_handle_t& path_handle) const {
+        return get_graph()->path_front_end(path_handle);
+    }
+    
+    bool PositionOverlay::has_next_step(const step_handle_t& step_handle) const {
+        return get_graph()->has_next_step(step_handle);
+    }
+    
+    bool PositionOverlay::has_previous_step(const step_handle_t& step_handle) const {
+        return get_graph()->has_previous_step(step_handle);
+    }
+    
+    step_handle_t PositionOverlay::get_next_step(const step_handle_t& step_handle) const {
+        return get_graph()->get_next_step(step_handle);
+    }
+    
+    step_handle_t PositionOverlay::get_previous_step(const step_handle_t& step_handle) const {
+        return get_graph()->get_previous_step(step_handle);
+    }
+    
+    path_handle_t PositionOverlay::get_path_handle_of_step(const step_handle_t& step_handle) const {
+        return get_graph()->get_path_handle_of_step(step_handle);
+    }
+    
+    bool PositionOverlay::for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const {
+        return get_graph()->for_each_path_handle(iteratee);
+    }
+    
+    bool PositionOverlay::for_each_step_on_handle_impl(const handle_t& handle,
+                                                       const function<bool(const step_handle_t&)>& iteratee) const {
+        return get_graph()->for_each_step_on_handle(handle, iteratee);
+    }
+    
+    size_t PositionOverlay::get_path_length(const path_handle_t& path_handle) const {
+        const auto& path_step_by_position = step_by_position.at(path_handle);
+        auto last = path_step_by_position.rbegin();
+        if (last == path_step_by_position.rend()) {
+            return 0;
+        }
+        else {
+            return (last->first
+                    + get_graph()->get_length(get_graph()->get_handle_of_step(last->second))
+                    - min_path_offset.at(path_handle));
+        }
+        
+    }
+    
+    size_t PositionOverlay::get_position_of_step(const step_handle_t& step) const {
+        return offset_by_step.at(step) - min_path_offset.at(get_path_handle_of_step(step));
+    }
+    
+    step_handle_t PositionOverlay::get_step_at_position(const path_handle_t& path,
+                                                        const size_t& position) const {
+        
+        int64_t lookup_position = position + min_path_offset.at(path);
+        auto iter = step_by_position.at(path).lower_bound(lookup_position);
+        if (position - iter->first >= get_graph()->get_length(get_graph()->get_handle_of_step(iter->second))) {
+            // this only occurs if the position was past the last base in the path
+            return get_graph()->path_end();
+        }
+        else {
+            return iter->second;
+        }
+    }
+    
+    handle_t PositionOverlay::get_underlying_handle(const handle_t& handle) const {
+        return handle;
+    }
+    
+    void PositionOverlay::index_path_positions() {
+        
+        get_graph()->for_each_path_handle([&](const path_handle_t& path) {
+            int64_t offset = 0;
+            min_path_offset[path] = offset;
+            auto& path_step_by_position = step_by_position[path];
+            get_graph()->for_each_step_in_path(path, [&](const step_handle_t& step) {
+                offset_by_step[step] = offset;
+                path_step_by_position[offset] = step;
+                get_graph()->get_length(get_graph()->get_handle_of_step(step));
+            });
+        });
+    }
+    
+    MutablePositionOverlay::MutablePositionOverlay(MutablePathDeletableHandleGraph* graph) : PositionOverlay(graph) {
+        
+    }
+    
+    MutablePositionOverlay::MutablePositionOverlay() {
+        
+    }
+    
+    MutablePositionOverlay::~MutablePositionOverlay() {
+        
+    }
+    
+    handle_t MutablePositionOverlay::create_handle(const std::string& sequence) {
+        return get_graph()->create_handle(sequence);
+    }
+    
+    handle_t MutablePositionOverlay::create_handle(const std::string& sequence, const nid_t& id) {
+        return get_graph()->create_handle(sequence, id);
+    }
+    
+    void MutablePositionOverlay::destroy_handle(const handle_t& handle) {
+        // note: destroying a handle on a path is U.B., so don't worry about it
+        get_graph()->destroy_handle(handle);
+    }
+    
+    void MutablePositionOverlay::create_edge(const handle_t& left, const handle_t& right) {
+        get_graph()->create_handle(left, right);
+    }
+    
+    void MutablePositionOverlay::destroy_edge(const handle_t& left, const handle_t& right) {
+        get_graph()->destroy_edge(left, right);
+    }
+    
+    void clear(void) {
+        get_graph()->clear();
+        offset_by_step.clear();
+        step_by_position.clear();
+    }
+    
+    handle_t MutablePositionOverlay::apply_orientation(const handle_t& handle) {
+        // this will reverse the orientation of the handle on paths, so we need to update
+        // the corresponding steps
+        
+        // remove the previous annotations by step
+        for_each_step_on_handle(handle, [&](const step_handle_t& step) {
+            offset_by_step.erase(step);
+        });
+        
+        // do the flip
+        handle_t new_handle = get_graph()->apply_orientation(handle);
+        
+        for_each_step_on_handle(new_handle, [&](const step_handle_t& new_step) {
+            
+            // walk backwards until the beginning of the path or a step that still has its
+            // position recorded
+            aauto prev = get_previous_step(new_step);
+            size_t walked_distance = 0;
+            while (!offset_by_step.count(prev)) {
+                walked_distance += get_length(prev);
+                // mid-loop stopping condition is also valid for circular paths
+                if (prev == path_begin(get_path_handle_of_step(new_step))) {
+                    break;
+                }
+                prev = get_previous_step(prev);
+            }
+            
+            // compute the position based on this walk
+            int64_t position;
+            if (prev == path_begin(get_path_handle_of_step(new_step))) {
+                position = walked_distance + min_path_offset[get_path_handle_of_step(new_step)];
+            }
+            else {
+                position = offset_by_step[prev] + get_length(get_handle_of_step(prev)) + walked_distance;
+            }
+            
+            offset_by_step[new_step] = position;
+            step_by_position[get_handle_of_step(new_step)][position] = new_step;
+        });
+        
+        return new_handle;
+    }
+    
+    vector<handle_t> MutablePositionOverlay::divide_handle(const handle_t& handle, const std::vector<size_t>& offsets) {
+        
+        // the old steps need to be erased in the hash table
+        for_each_step_on_handle(handle, [&](const step_handle_t& step) {
+            offset_by_step.erase(step)
+        });
+        
+        auto new_handles = get_graph()->divide_handle(handle, offsets);
+        
+        for_each_step_on_handle(new_handles.front(), [&](const step_handle_t& new_step) {
+            
+            // we may have already re-annotated this occurrence starting from a different step
+            if (offset_by_step.count(new_step)) {
+                return;
+            }
+            
+            // walk backwards until the beginning of the path or a step that still has its
+            // position recorded
+            auto prev = get_previous_step(new_step);
+            size_t walked_distance = 0;
+            while (!offset_by_step.count(prev)) {
+                walked_distance += get_length(prev);
+                // mid-loop stopping condition is also valid for circular paths
+                if (prev == path_begin(get_path_handle_of_step(new_step))) {
+                    break;
+                }
+                prev = get_previous_step(prev);
+            }
+            
+            // compute the position based on this walk
+            int64_t position;
+            if (prev == path_begin(get_path_handle_of_step(new_step))) {
+                position = walked_distance + min_path_offset[get_path_handle_of_step(new_step)];
+            }
+            else {
+                position = offset_by_step[prev] + get_length(get_handle_of_step(prev)) + walked_distance;
+            }
+            
+            // add position annotations for all of the new handles (can also soak up adjacent
+            // occurrences of the same node on this path)
+            auto& path_step_by_position = step_by_position[get_path_handle_of_step(step)];
+            for (auto step = get_next_step(prev);
+                 step != path_end(get_path_handle_of_step(new_step)) && !offset_by_step.count(step);
+                 step = get_next_step(step)) {
+                
+                path_step_by_position[position] = step;
+                offset_by_step[step] = position;
+                
+                position += get_length(get_handle_of_step(step));
+            }
+        });
+        
+        return new_handles;
+    }
+    
+    void MutablePositionOverlay::optimize(bool allow_id_reassignment) {
+        // optimization may include arbitrary changes that invalidate all handles, need to reindex
+        get_graph()->optimize(allow_id_reassignment);
+        reindex_path_position();
+    }
+    
+    void MutablePositionOverlay::apply_ordering(const vector<handle_t>& order, bool compact_ids) {
+        // depending on the implementation, this may change the values of the handles, which
+        // may change the value of the steps, so the index could be entirely invalidated
+        get_graph->apply_ordering(order, compact_ids);
+        reindex_path_position();
+    }
+    
+    void MutablePositionOverlay::destroy_path(const path_handle_t& path) {
+        
+        // erase the path's indexes
+        step_by_position.erase(path);
+        for_each_step_in_path(path, [&](const step_handle_t& step) {
+            offset_by_step.erase(step);
+        });
+        
+        get_graph()->destroy_path(path);
+    }
+    
+    path_handle_t MutablePositionOverlay::create_path_handle(const string& name, bool is_circular) {
+        path_handle_t path_handle = get_graph()->create_path_handle(name, is_circular);
+        min_path_offset[path_handle] = 0;
+        step_by_position[path_handle] = map<int64_t, step_handle_t>();
+    }
+    
+    step_handle_t MutablePositionOverlay::append_step(const path_handle_t& path, const handle_t& to_append) {
+        int64_t position = get_path_length(path) + min_path_offset[path];
+        step_handle_t step = get_graph()->append_step(path, to_append);
+        step_by_position[path][position] = step;
+        offset_by_step[step] = position;
+        return step;
+    }
+    
+    step_handle_t MutablePositionOverlay::prepend_step(const path_handle_t& path, const handle_t& to_prepend) {
+        min_path_offset[path] -= get_length(to_prepend);
+        step_handle_t step = get_graph()->prepend_step(path, to_prepend);
+        offset_by_step[step] = min_path_offset[path];
+        step_by_position[path][min_path_offset[path]] = step;
+        return step;
+    }
+    
+    pair<step_handle_t, step_handle_t> MutablePositionOverlay::rewrite_segment(const step_handle_t& segment_begin,
+                                                                               const step_handle_t& segment_end,
+                                                                               const vector<handle_t>& new_segment) {
+        
+        // TODO: there really is no way to do this efficiently since it can shift the offsets downstream...
+        
+        int64_t offset = offset_by_step[segment_begin];
+        
+        // erase the records of all steps from the beginning of the segment onwards
+        auto& path_step_by_position = step_by_position[get_path_handle_of_step(segment_begin)];
+        path_step_by_position.erase(path_step_by_position.find(starting_offset), path_step_by_position.end());
+        for (auto step = segment_begin; step != path_end(get_path_handle_of_step(segment_begin)); step = get_next_step(step)) {
+            offset_by_step.erase(step);
+        }
+        
+        auto new_range = get_graph()->rewrite_segment(segment_begin, segment_end, new_segment);
+        
+        // reindex the new suffix of the path
+        for (auto step = new_range.first; step != path_end(get_path_handle_of_step(new_range.first)); step = get_next_step(step)) {
+            offset_by_step[step] = offset;
+            path_step_by_position[offset] = step;
+            offset += get_length(get_handle_of_step(step));
+        }
+        
+        return new_range;
+    }
+    
+    void MutablePositionOverlay::set_circularity(const path_handle_t& path, bool circular) {
+        return get_graph()->set_circularity(path, circular);
+    }
+    
+    void MutablePositionOverlay::reindex_path_position() {
+        
+        // rebuild the indexes
+        step_by_position.clear();
+        offset_by_step.clear();
+        min_path_offset.clear();
+        index_path_positions();
+    }
+}

--- a/src/test_libbdsg.cpp
+++ b/src/test_libbdsg.cpp
@@ -1,0 +1,1627 @@
+//
+//  test_libbdsg.cpp
+//  
+// Contains tests for the data structures in libbdsg
+//
+
+#include <stdio.h>
+#include <iostream>
+#include <vector>
+#include <cassert>
+
+#include "odgi.hpp"
+#include "packed_graph.hpp"
+#include "hash_graph.hpp"
+#include "packed_structs.hpp"
+
+using namespace bdsg;
+using namespace handlegraph;
+using namespace std;
+
+void test_deletable_handle_graphs() {
+    
+    // first batch of tests
+    {
+        vector<DeletableHandleGraph*> implementations;
+        
+        // Add implementations
+        
+        PackedGraph pg;
+        implementations.push_back(&pg);
+        
+        HashGraph hg;
+        implementations.push_back(&hg);
+        
+        ODGI og;
+        implementations.push_back(&og);
+        
+        // And test them
+        
+        for (DeletableHandleGraph* implementation : implementations) {
+            
+            DeletableHandleGraph& graph = *implementation;
+            
+            assert(graph.get_node_count() == 0);
+            
+            handle_t h = graph.create_handle("ATG", 2);
+            
+            // DeletableHandleGraph has correct structure after creating a node
+            {
+                assert(graph.get_sequence(h) == "ATG");
+                assert(graph.get_sequence(graph.flip(h)) == "CAT");
+                assert(graph.get_base(h, 1) == 'T');
+                assert(graph.get_base(graph.flip(h), 2) == 'T');
+                assert(graph.get_subsequence(h, 1, 3) == "TG");
+                assert(graph.get_subsequence(graph.flip(h), 0, 2) == "CA");
+                assert(graph.get_length(h) == 3);
+                assert(graph.has_node(graph.get_id(h)));
+                assert(!graph.has_node(graph.get_id(h) + 1));
+                
+                assert(graph.get_handle(graph.get_id(h)) == h);
+                assert(!graph.get_is_reverse(h));
+                assert(graph.get_is_reverse(graph.flip(h)));
+                
+                assert(graph.get_node_count() == 1);
+                assert(graph.min_node_id() == graph.get_id(h));
+                assert(graph.max_node_id() == graph.get_id(h));
+                
+                graph.follow_edges(h, true, [](const handle_t& prev) {
+                    assert(false);
+                    return true;
+                });
+                graph.follow_edges(h, false, [](const handle_t& next) {
+                    assert(false);
+                    return true;
+                });
+            }
+            
+            handle_t h2 = graph.create_handle("CT", 1);
+            
+            // DeletableHandleGraph has correct structure after creating a node at the beginning of ID space
+            {
+                
+                assert(graph.get_sequence(h2) == "CT");
+                assert(graph.get_sequence(graph.flip(h2)) == "AG");
+                assert(graph.get_base(h2, 1) == 'T');
+                assert(graph.get_base(graph.flip(h2), 0) == 'A');
+                assert(graph.get_subsequence(h2, 1, 10) == "T");
+                assert(graph.get_subsequence(graph.flip(h2), 0, 2) == "AG");
+                assert(graph.get_length(h2) == 2);
+                assert(graph.has_node(graph.get_id(h2)));
+                assert(!graph.has_node(max(graph.get_id(h), graph.get_id(h2)) + 1));
+                
+                assert(graph.get_handle(graph.get_id(h2)) == h2);
+                
+                assert(graph.get_node_count() == 2);
+                assert(graph.min_node_id() == graph.get_id(h2));
+                assert(graph.max_node_id() == graph.get_id(h));
+                
+                graph.follow_edges(h2, true, [](const handle_t& prev) {
+                    assert(false);
+                    return true;
+                });
+                graph.follow_edges(h2, false, [](const handle_t& next) {
+                    assert(false);
+                    return true;
+                });
+            }
+            
+            // creating and accessing a node at the end of ID space
+            
+            handle_t h3 = graph.create_handle("GAC", 4);
+            
+            // DeletableHandleGraph has correct structure after creating a node at the end of ID space
+            {
+                assert(graph.get_sequence(h3) == "GAC");
+                assert(graph.get_sequence(graph.flip(h3)) == "GTC");
+                assert(graph.get_base(h3, 1) == 'A');
+                assert(graph.get_base(graph.flip(h3), 0) == 'G');
+                assert(graph.get_subsequence(h3, 1, 1) == "A");
+                assert(graph.get_subsequence(graph.flip(h3), 0, 5) == "GTC");
+                assert(graph.get_length(h3) == 3);
+                
+                assert(graph.get_handle(graph.get_id(h3)) == h3);
+                
+                assert(graph.get_node_count() == 3);
+                assert(graph.min_node_id() == graph.get_id(h2));
+                assert(graph.max_node_id() == graph.get_id(h3));
+                
+                graph.follow_edges(h3, true, [](const handle_t& prev) {
+                    assert(false);
+                    return true;
+                });
+                graph.follow_edges(h3, false, [](const handle_t& next) {
+                    assert(false);
+                    return true;
+                });
+            }
+            
+            
+            // creating and accessing in the middle of ID space
+            
+            handle_t h4 = graph.create_handle("T", 3);
+            
+            // DeletableHandleGraph has correct structure after creating a node in the middle of ID space
+            {
+                assert(graph.get_sequence(h4) == "T");
+                assert(graph.get_sequence(graph.flip(h4)) == "A");
+                assert(graph.get_length(h4) == 1);
+                
+                assert(graph.get_handle(graph.get_id(h4)) == h4);
+                
+                assert(graph.get_node_count() == 4);
+                assert(graph.min_node_id() == graph.get_id(h2));
+                assert(graph.max_node_id() == graph.get_id(h3));
+                
+                graph.follow_edges(h4, true, [](const handle_t& prev) {
+                    assert(false);
+                    return true;
+                });
+                graph.follow_edges(h4, false, [](const handle_t& next) {
+                    assert(false);
+                    return true;
+                });
+            }
+            
+            graph.create_edge(h, h2);
+            
+            bool found1 = false, found2 = false, found3 = false, found4 = false;
+            int count1 = 0, count2 = 0, count3 = 0, count4 = 0;
+            
+            // DeletableHandleGraph has correct structure after creating an edge
+            {
+                graph.follow_edges(h, false, [&](const handle_t& next) {
+                    if (next == h2) {
+                        found1 = true;
+                    }
+                    count1++;
+                    return true;
+                });
+                graph.follow_edges(h2, true, [&](const handle_t& prev) {
+                    if (prev == h) {
+                        found2 = true;
+                    }
+                    count2++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h), true, [&](const handle_t& prev) {
+                    if (prev == graph.flip(h2)) {
+                        found3 = true;
+                    }
+                    count3++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h2), false, [&](const handle_t& next) {
+                    if (next == graph.flip(h)) {
+                        found4 = true;
+                    }
+                    count4++;
+                    return true;
+                });
+                assert(count1 == 1);
+                assert(count2 == 1);
+                assert(count3 == 1);
+                assert(count4 == 1);
+                assert(found1);
+                assert(found2);
+                assert(found3);
+                assert(found4);
+                
+                count1 = count2 = count3 = count4 = 0;
+                found1 = found2 = found3 = found4 = false;
+            }
+            
+            graph.create_edge(h, graph.flip(h3));
+            
+            bool found5 = false, found6 = false, found7 = false, found8 = false;
+            int count5 = 0, count6 = 0;
+            
+            // DeletableHandleGraph has correct structure after creating an edge with a traversal
+            {
+                
+                graph.follow_edges(h, false, [&](const handle_t& next) {
+                    if (next == h2) {
+                        found1 = true;
+                    }
+                    else if (next == graph.flip(h3)) {
+                        found2 = true;
+                    }
+                    count1++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h), true, [&](const handle_t& prev) {
+                    if (prev == graph.flip(h2)) {
+                        found3 = true;
+                    }
+                    else if (prev == h3) {
+                        found4 = true;
+                    }
+                    count2++;
+                    return true;
+                });
+                graph.follow_edges(h2, true, [&](const handle_t& prev) {
+                    if (prev == h) {
+                        found5 = true;
+                    }
+                    count3++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h2), false, [&](const handle_t& next) {
+                    if (next == graph.flip(h)) {
+                        found6 = true;
+                    }
+                    count4++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h3), true, [&](const handle_t& prev) {
+                    if (prev == h) {
+                        found7 = true;
+                    }
+                    count5++;
+                    return true;
+                });
+                graph.follow_edges(h3, false, [&](const handle_t& next) {
+                    if (next == graph.flip(h)) {
+                        found8 = true;
+                    }
+                    count6++;
+                    return true;
+                });
+                assert(count1 == 2);
+                assert(count2 == 2);
+                assert(count3 == 1);
+                assert(count4 == 1);
+                assert(count5 == 1);
+                assert(count6 == 1);
+                assert(found1);
+                assert(found2);
+                assert(found3);
+                assert(found4);
+                assert(found5);
+                assert(found6);
+                assert(found7);
+                assert(found8);
+                
+                count1 = count2 = count3 = count4 = count5 = count6 = 0;
+                found1 = found2 = found3 = found4 = found5 = found6 = found7 = found8 = false;
+            }
+            
+            graph.create_edge(h4, graph.flip(h4));
+            
+            // DeletableHandleGraph has correct structure after creating a reversing self-loop
+            {
+                graph.follow_edges(h4, false, [&](const handle_t& next) {
+                    if (next == graph.flip(h4)) {
+                        found1 = true;
+                    }
+                    count1++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h4), true, [&](const handle_t& prev) {
+                    if (prev == h4) {
+                        found2 = true;
+                    }
+                    count2++;
+                    return true;
+                });
+                assert(count1 == 1);
+                assert(count2 == 1);
+                assert(found1);
+                assert(found2);
+                
+                count1 = count2 = 0;
+                found1 = found2 = false;
+            }
+            
+            graph.create_edge(h, graph.flip(h4));
+            graph.create_edge(graph.flip(h3), h4);
+            
+            graph.destroy_edge(h, graph.flip(h4));
+            graph.destroy_edge(graph.flip(h3), h4);
+            
+            // DeletableHandleGraph has correct structure after creating and deleting edges
+            {
+                graph.follow_edges(h, false, [&](const handle_t& next) {
+                    if (next == h2) {
+                        found1 = true;
+                    }
+                    else if (next == graph.flip(h3)) {
+                        found2 = true;
+                    }
+                    count1++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h), true, [&](const handle_t& prev) {
+                    if (prev == graph.flip(h2)) {
+                        found3 = true;
+                    }
+                    else if (prev == h3) {
+                        found4 = true;
+                    }
+                    count2++;
+                    return true;
+                });
+                graph.follow_edges(h2, true, [&](const handle_t& prev) {
+                    if (prev == h) {
+                        found5 = true;
+                    }
+                    count3++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h2), false, [&](const handle_t& next) {
+                    if (next == graph.flip(h)) {
+                        found6 = true;
+                    }
+                    count4++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h3), true, [&](const handle_t& prev) {
+                    if (prev == h) {
+                        found7 = true;
+                    }
+                    count5++;
+                    return true;
+                });
+                graph.follow_edges(h3, false, [&](const handle_t& next) {
+                    if (next == graph.flip(h)) {
+                        found8 = true;
+                    }
+                    count6++;
+                    return true;
+                });
+                assert(count1 == 2);
+                assert(count2 == 2);
+                assert(count3 == 1);
+                assert(count4 == 1);
+                assert(count5 == 1);
+                assert(count6 == 1);
+                assert(found1);
+                assert(found2);
+                assert(found3);
+                assert(found4);
+                assert(found5);
+                assert(found6);
+                assert(found7);
+                assert(found8);
+                
+                count1 = count2 = count3 = count4 = count5 = count6 = 0;
+                found1 = found2 = found3 = found4 = found5 = found6 = found7 = found8 = false;
+                
+                graph.follow_edges(h4, false, [&](const handle_t& next) {
+                    if (next == graph.flip(h4)) {
+                        found1 = true;
+                    }
+                    count1++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h4), true, [&](const handle_t& prev) {
+                    if (prev == h4) {
+                        found2 = true;
+                    }
+                    count2++;
+                    return true;
+                });
+                assert(count1 == 1);
+                assert(count2 == 1);
+                assert(found1);
+                assert(found2);
+                
+                count1 = count2 = 0;
+                found1 = found2 = false;
+            }
+            
+            handle_t h5 = graph.create_handle("GGACC");
+            
+            // make some edges to ensure that deleting is difficult
+            graph.create_edge(h, h5);
+            graph.create_edge(h5, h);
+            graph.create_edge(graph.flip(h5), h2);
+            graph.create_edge(h3, graph.flip(h5));
+            graph.create_edge(h3, h5);
+            graph.create_edge(h5, h4);
+            
+            graph.destroy_handle(h5);
+            
+            // DeletableHandleGraph has correct structure after creating and deleting a node
+            {
+                
+                graph.follow_edges(h, false, [&](const handle_t& next) {
+                    if (next == h2) {
+                        found1 = true;
+                    }
+                    else if (next == graph.flip(h3)) {
+                        found2 = true;
+                    }
+                    count1++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h), true, [&](const handle_t& prev) {
+                    if (prev == graph.flip(h2)) {
+                        found3 = true;
+                    }
+                    else if (prev == h3) {
+                        found4 = true;
+                    }
+                    count2++;
+                    return true;
+                });
+                graph.follow_edges(h2, true, [&](const handle_t& prev) {
+                    if (prev == h) {
+                        found5 = true;
+                    }
+                    count3++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h2), false, [&](const handle_t& next) {
+                    if (next == graph.flip(h)) {
+                        found6 = true;
+                    }
+                    count4++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h3), true, [&](const handle_t& prev) {
+                    if (prev == h) {
+                        found7 = true;
+                    }
+                    count5++;
+                    return true;
+                });
+                graph.follow_edges(h3, false, [&](const handle_t& next) {
+                    if (next == graph.flip(h)) {
+                        found8 = true;
+                    }
+                    count6++;
+                    return true;
+                });
+                assert(count1 == 2);
+                assert(count2 == 2);
+                assert(count3 == 1);
+                assert(count4 == 1);
+                assert(count5 == 1);
+                assert(count6 == 1);
+                assert(found1);
+                assert(found2);
+                assert(found3);
+                assert(found4);
+                assert(found5);
+                assert(found6);
+                assert(found7);
+                assert(found8);
+                
+                count1 = count2 = count3 = count4 = count5 = count6 = 0;
+                found1 = found2 = found3 = found4 = found5 = found6 = found7 = found8 = false;
+                
+                graph.follow_edges(h4, false, [&](const handle_t& next) {
+                    if (next == graph.flip(h4)) {
+                        found1 = true;
+                    }
+                    count1++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h4), true, [&](const handle_t& prev) {
+                    if (prev == h4) {
+                        found2 = true;
+                    }
+                    count2++;
+                    return true;
+                });
+                assert(count1 == 1);
+                assert(count2 == 1);
+                assert(found1);
+                assert(found2);
+                
+                count1 = count2 = 0;
+                found1 = found2 = false;
+            }
+            
+            // DeletableHandleGraph has correct structure after swapping nodes
+            {
+                
+                graph.follow_edges(h, false, [&](const handle_t& next) {
+                    if (next == h2) {
+                        found1 = true;
+                    }
+                    else if (next == graph.flip(h3)) {
+                        found2 = true;
+                    }
+                    count1++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h), true, [&](const handle_t& prev) {
+                    if (prev == graph.flip(h2)) {
+                        found3 = true;
+                    }
+                    else if (prev == h3) {
+                        found4 = true;
+                    }
+                    count2++;
+                    return true;
+                });
+                graph.follow_edges(h2, true, [&](const handle_t& prev) {
+                    if (prev == h) {
+                        found5 = true;
+                    }
+                    count3++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h2), false, [&](const handle_t& next) {
+                    if (next == graph.flip(h)) {
+                        found6 = true;
+                    }
+                    count4++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h3), true, [&](const handle_t& prev) {
+                    if (prev == h) {
+                        found7 = true;
+                    }
+                    count5++;
+                    return true;
+                });
+                graph.follow_edges(h3, false, [&](const handle_t& next) {
+                    if (next == graph.flip(h)) {
+                        found8 = true;
+                    }
+                    count6++;
+                    return true;
+                });
+                assert(count1 == 2);
+                assert(count2 == 2);
+                assert(count3 == 1);
+                assert(count4 == 1);
+                assert(count5 == 1);
+                assert(count6 == 1);
+                assert(found1);
+                assert(found2);
+                assert(found3);
+                assert(found4);
+                assert(found5);
+                assert(found6);
+                assert(found7);
+                assert(found8);
+                
+                count1 = count2 = count3 = count4 = count5 = count6 = 0;
+                found1 = found2 = found3 = found4 = found5 = found6 = found7 = found8 = false;
+                
+                graph.follow_edges(h4, false, [&](const handle_t& next) {
+                    if (next == graph.flip(h4)) {
+                        found1 = true;
+                    }
+                    count1++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h4), true, [&](const handle_t& prev) {
+                    if (prev == h4) {
+                        found2 = true;
+                    }
+                    count2++;
+                    return true;
+                });
+                assert(count1 == 1);
+                assert(count2 == 1);
+                assert(found1);
+                assert(found2);
+                
+                count1 = count2 = 0;
+                found1 = found2 = false;
+            }
+            
+            // DeletableHandleGraph visits all nodes with for_each_handle
+            {
+                graph.for_each_handle([&](const handle_t& handle) {
+                    if (handle == h) {
+                        found1 = true;
+                    }
+                    else if (handle == h2) {
+                        found2 = true;
+                    }
+                    else if (handle == h3) {
+                        found3 = true;
+                    }
+                    else if (handle == h4) {
+                        found4 = true;
+                    }
+                    else {
+                        assert(false);
+                    }
+                    return true;
+                });
+                
+                assert(found1);
+                assert(found2);
+                assert(found3);
+                assert(found4);
+                
+                found1 = found2 = found3 = found4 = false;
+            }
+            
+            // to make sure the sequence reverse complemented correctly
+            int i = 0;
+            auto check_rev_comp = [&](const std::string& seq1, const std::string& seq2) {
+                i++;
+                assert(seq1.size() == seq2.size());
+                auto it = seq1.begin();
+                auto rit = seq2.rbegin();
+                for (; it != seq1.end(); it++) {
+                    if (*it == 'A') {
+                        assert(*rit == 'T');
+                    }
+                    else if (*it == 'C') {
+                        assert(*rit == 'G');
+                    }
+                    else if (*it == 'G') {
+                        assert(*rit == 'C');
+                    }
+                    else if (*it == 'T') {
+                        assert(*rit == 'A');
+                    }
+                    else if (*it == 'N') {
+                        assert(*rit == 'N');
+                    }
+                    else {
+                        assert(false);
+                    }
+                    
+                    rit++;
+                }
+            };
+            
+            
+            int count7 = 0, count8 = 0;
+            
+            // DeletableHandleGraph correctly reverses a node
+            {
+                
+                string seq1 = graph.get_sequence(h);
+                h = graph.apply_orientation(graph.flip(h));
+                
+                // check the sequence
+                string rev_seq1 = graph.get_sequence(h);
+                check_rev_comp(seq1, rev_seq1);
+                
+                // check that the edges are what we expect
+                
+                graph.follow_edges(h, false, [&](const handle_t& next) {
+                    count1++;
+                    return true;
+                });
+                graph.follow_edges(h, true, [&](const handle_t& prev) {
+                    if (prev == graph.flip(h2)) {
+                        found1 = true;
+                    }
+                    else if (prev == h3) {
+                        found2 = true;
+                    }
+                    count2++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h), true, [&](const handle_t& next) {
+                    count3++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h), false, [&](const handle_t& prev) {
+                    if (prev == h2) {
+                        found3 = true;
+                    }
+                    else if (prev == graph.flip(h3)) {
+                        found4 = true;
+                    }
+                    count4++;
+                    return true;
+                });
+                graph.follow_edges(h2, true, [&](const handle_t& prev) {
+                    if (prev == graph.flip(h)) {
+                        found5 = true;
+                    }
+                    count5++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h2), false, [&](const handle_t& next) {
+                    if (next == h) {
+                        found6 = true;
+                    }
+                    count6++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h3), true, [&](const handle_t& prev) {
+                    if (prev == graph.flip(h)) {
+                        found7 = true;
+                    }
+                    count7++;
+                    return true;
+                });
+                graph.follow_edges(h3, false, [&](const handle_t& next) {
+                    if (next == h) {
+                        found8 = true;
+                    }
+                    count8++;
+                    return true;
+                });
+                assert(count1 == 0);
+                assert(count2 == 2);
+                assert(count3 == 0);
+                assert(count4 == 2);
+                assert(count5 == 1);
+                assert(count6 == 1);
+                assert(count7 == 1);
+                assert(count8 == 1);
+                assert(found1);
+                assert(found2);
+                assert(found3);
+                assert(found4);
+                assert(found5);
+                assert(found6);
+                assert(found7);
+                assert(found8);
+                
+                count1 = count2 = count3 = count4 = count5 = count6 = count7 = count8 = 0;
+                found1 = found2 = found3 = found4 = found5 = found6 = found7 = found8 = false;
+                
+                
+                // and now switch it back to the same orientation and repeat the topology checks
+                
+                h = graph.apply_orientation(graph.flip(h));
+                
+                graph.follow_edges(h, false, [&](const handle_t& next) {
+                    if (next == h2) {
+                        found1 = true;
+                    }
+                    else if (next == graph.flip(h3)) {
+                        found2 = true;
+                    }
+                    count1++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h), true, [&](const handle_t& prev) {
+                    if (prev == graph.flip(h2)) {
+                        found3 = true;
+                    }
+                    else if (prev == h3) {
+                        found4 = true;
+                    }
+                    count2++;
+                    return true;
+                });
+                graph.follow_edges(h2, true, [&](const handle_t& prev) {
+                    if (prev == h) {
+                        found5 = true;
+                    }
+                    count3++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h2), false, [&](const handle_t& next) {
+                    if (next == graph.flip(h)) {
+                        found6 = true;
+                    }
+                    count4++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h3), true, [&](const handle_t& prev) {
+                    if (prev == h) {
+                        found7 = true;
+                    }
+                    count5++;
+                    return true;
+                });
+                graph.follow_edges(h3, false, [&](const handle_t& next) {
+                    if (next == graph.flip(h)) {
+                        found8 = true;
+                    }
+                    count6++;
+                    return true;
+                });
+                assert(count1 == 2);
+                assert(count2 == 2);
+                assert(count3 == 1);
+                assert(count4 == 1);
+                assert(count5 == 1);
+                assert(count6 == 1);
+                assert(found1);
+                assert(found2);
+                assert(found3);
+                assert(found4);
+                assert(found5);
+                assert(found6);
+                assert(found7);
+                assert(found8);
+                
+                count1 = count2 = count3 = count4 = count5 = count6 = 0;
+                found1 = found2 = found3 = found4 = found5 = found6 = found7 = found8 = false;
+                
+                graph.follow_edges(h4, false, [&](const handle_t& next) {
+                    if (next == graph.flip(h4)) {
+                        found1 = true;
+                    }
+                    count1++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h4), true, [&](const handle_t& prev) {
+                    if (prev == h4) {
+                        found2 = true;
+                    }
+                    count2++;
+                    return true;
+                });
+                assert(count1 == 1);
+                assert(count2 == 1);
+                assert(found1);
+                assert(found2);
+                
+                count1 = count2 = 0;
+                found1 = found2 = false;
+            }
+            
+            vector<handle_t> parts = graph.divide_handle(h, vector<size_t>{1, 2});
+            
+            int count9 = 0, count10 = 0, count11 = 0, count12 = 0;
+            bool found9 = false, found10 = false, found11 = false, found12 = false, found13 = false, found14 = false;
+            
+            // DeletableHandleGraph can correctly divide a node
+            {
+                
+                assert(parts.size() == 3);
+                
+                assert(graph.get_sequence(parts[0]) == "A");
+                assert(graph.get_length(parts[0]) == 1);
+                assert(graph.get_sequence(parts[1]) == "T");
+                assert(graph.get_length(parts[1]) == 1);
+                assert(graph.get_sequence(parts[2]) == "G");
+                assert(graph.get_length(parts[2]) == 1);
+                
+                
+                graph.follow_edges(parts[0], false, [&](const handle_t& next) {
+                    if (next == parts[1]) {
+                        found1 = true;
+                    }
+                    count1++;
+                    return true;
+                });
+                graph.follow_edges(parts[0], true, [&](const handle_t& prev) {
+                    count2++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(parts[0]), true, [&](const handle_t& prev) {
+                    if (prev == graph.flip(parts[1])) {
+                        found2 = true;
+                    }
+                    count3++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(parts[0]), false, [&](const handle_t& next) {
+                    count4++;
+                    return true;
+                });
+                
+                graph.follow_edges(parts[1], false, [&](const handle_t& next) {
+                    if (next == parts[2]) {
+                        found3 = true;
+                    }
+                    count5++;
+                    return true;
+                });
+                graph.follow_edges(parts[1], true, [&](const handle_t& prev) {
+                    if (prev == parts[0]) {
+                        found4 = true;
+                    }
+                    count6++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(parts[1]), true, [&](const handle_t& prev) {
+                    if (prev == graph.flip(parts[2])) {
+                        found5 = true;
+                    }
+                    count7++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(parts[1]), false, [&](const handle_t& next) {
+                    if (next == graph.flip(parts[0])) {
+                        found6 = true;
+                    }
+                    count8++;
+                    return true;
+                });
+                
+                graph.follow_edges(parts[2], false, [&](const handle_t& next) {
+                    if (next == h2) {
+                        found7 = true;
+                    }
+                    else if (next == graph.flip(h3)) {
+                        found8 = true;
+                    }
+                    count9++;
+                    return true;
+                });
+                graph.follow_edges(parts[2], true, [&](const handle_t& prev) {
+                    if (prev == parts[1]) {
+                        found9 = true;
+                    }
+                    count10++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(parts[2]), true, [&](const handle_t& prev) {
+                    if (prev == graph.flip(h2)) {
+                        found10 = true;
+                    }
+                    else if (prev == h3) {
+                        found11 = true;
+                    }
+                    count11++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(parts[2]), false, [&](const handle_t& next) {
+                    if (next == graph.flip(parts[1])) {
+                        found12 = true;
+                    }
+                    count12++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(h3), true, [&](const handle_t& prev) {
+                    if (prev == parts[2]) {
+                        found13 = true;
+                    }
+                    return true;
+                });
+                graph.follow_edges(h2, true, [&](const handle_t& prev) {
+                    if (prev == parts[2]) {
+                        found14 = true;
+                    }
+                    return true;
+                });
+                
+                assert(count1 == 1);
+                assert(count2 == 0);
+                assert(count3 == 1);
+                assert(count4 == 0);
+                assert(count5 == 1);
+                assert(count6 == 1);
+                assert(count7 == 1);
+                assert(count8 == 1);
+                assert(count9 == 2);
+                assert(count10 == 1);
+                assert(count11 == 2);
+                assert(count12 == 1);
+                assert(found1);
+                assert(found2);
+                assert(found3);
+                assert(found4);
+                assert(found5);
+                assert(found6);
+                assert(found7);
+                assert(found8);
+                assert(found9);
+                assert(found10);
+                assert(found11);
+                assert(found12);
+                assert(found13);
+                assert(found14);
+                
+                count1 = count2 = count3 = count4 = count5 = count6 = count7 = count8 = count9 = count10 = count11 = count12 = 0;
+                found1 = found2 = found3 = found4 = found5 = found6 = found7 = found8 = found9 = found10 = found11 = found12 = false;
+            }
+            
+            vector<handle_t> rev_parts = graph.divide_handle(graph.flip(h3), vector<size_t>{1});
+            
+            // DeletableHandleGraph can correctly divide a node on the reverse strand
+            {
+                
+                assert(graph.get_sequence(rev_parts[0]) == "G");
+                assert(graph.get_length(rev_parts[0]) == 1);
+                assert(graph.get_is_reverse(rev_parts[0]));
+                assert(graph.get_sequence(rev_parts[1]) == "TC");
+                assert(graph.get_length(rev_parts[1]) == 2);
+                assert(graph.get_is_reverse(rev_parts[1]));
+                
+                graph.follow_edges(rev_parts[0], false, [&](const handle_t& next) {
+                    if (next == rev_parts[1]) {
+                        found1 = true;
+                    }
+                    count1++;
+                    return true;
+                });
+                graph.follow_edges(rev_parts[1], true, [&](const handle_t& prev) {
+                    if (prev == rev_parts[0]) {
+                        found2 = true;
+                    }
+                    count2++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(rev_parts[1]), false, [&](const handle_t& next) {
+                    if (next == graph.flip(rev_parts[0])) {
+                        found3 = true;
+                    }
+                    count3++;
+                    return true;
+                });
+                graph.follow_edges(graph.flip(rev_parts[0]), true, [&](const handle_t& prev) {
+                    if (prev == graph.flip(rev_parts[1])) {
+                        found4 = true;
+                    }
+                    count4++;
+                    return true;
+                });
+                graph.follow_edges(rev_parts[0], true, [&](const handle_t& prev) {
+                    if (prev == parts[2]) {
+                        found5 = true;
+                    }
+                    count5++;
+                    return true;
+                });
+                graph.follow_edges(rev_parts[1], false, [&](const handle_t& next) {
+                    count6++;
+                    return true;
+                });
+                
+                assert(count1 == 1);
+                assert(count2 == 1);
+                assert(count3 == 1);
+                assert(count4 == 1);
+                assert(count5 == 1);
+                assert(count6 == 0);
+                assert(found1);
+                assert(found2);
+                assert(found3);
+                assert(found4);
+                assert(found5);
+            }
+        }
+    }
+    
+    // second batch of test involving self loops
+    {
+        PackedGraph pg;
+        implementations.push_back(&pg);
+        
+        HashGraph hg;
+        implementations.push_back(&hg);
+        
+        ODGI og;
+        implementations.push_back(&og);
+        
+        for (DeletableHandleGraph* implementation : implementations) {
+            
+            DeletableHandleGraph& graph = *implementation;
+            
+            // initialize the graph
+            
+            handle_t h1 = graph.create_handle("A");
+            handle_t h2 = graph.create_handle("C");
+            
+            graph.create_edge(h1, h2);
+            graph.create_edge(graph.flip(h1), h2);
+            
+            // test for the right initial topology
+            bool found1 = false, found2 = false, found3 = false, found4 = false, found5 = false, found6 = false;
+            int count1 = 0, count2 = 0, count3 = 0, count4 = 0;
+            
+            graph.follow_edges(h1, false, [&](const handle_t& other) {
+                if (other == h2) {
+                    found1 = true;
+                }
+                count1++;
+            });
+            graph.follow_edges(h1, true, [&](const handle_t& other) {
+                if (other == graph.flip(h2)) {
+                    found2 = true;
+                }
+                count2++;
+            });
+            graph.follow_edges(h2, false, [&](const handle_t& other) {
+                count3++;
+            });
+            graph.follow_edges(h2, true, [&](const handle_t& other) {
+                if (other == h1) {
+                    found3 = true;
+                }
+                else if (other == graph.flip(h1)) {
+                    found4 = true;
+                }
+                count4++;
+            });
+            assert(found1);
+            assert(found2);
+            assert(found3);
+            assert(found4);
+            assert(count1 == 1);
+            assert(count2 == 1);
+            assert(count3 == 0);
+            assert(count4 == 2);
+            found1 = found2 = found3 = found4 = found5 = found6 = false;
+            count1 = count2 = count3 = count4 = 0;
+            
+            // flip a node and check if the orientation is correct
+            h1 = graph.apply_orientation(graph.flip(h1));
+            
+            graph.follow_edges(h1, false, [&](const handle_t& other) {
+                if (other == h2) {
+                    found1 = true;
+                }
+                count1++;
+            });
+            graph.follow_edges(h1, true, [&](const handle_t& other) {
+                if (other == graph.flip(h2)) {
+                    found2 = true;
+                }
+                count2++;
+            });
+            graph.follow_edges(h2, false, [&](const handle_t& other) {
+                count3++;
+            });
+            graph.follow_edges(h2, true, [&](const handle_t& other) {
+                if (other == h1) {
+                    found3 = true;
+                }
+                else if (other == graph.flip(h1)) {
+                    found4 = true;
+                }
+                count4++;
+            });
+            assert(found1);
+            assert(found2);
+            assert(found3);
+            assert(found4);
+            assert(count1 == 1);
+            assert(count2 == 1);
+            assert(count3 == 0);
+            assert(count4 == 2);
+            found1 = found2 = found3 = found4 = found5 = found6 = false;
+            count1 = count2 = count3 = count4 = 0;
+            
+            // create a new edge
+            
+            graph.create_edge(h1, graph.flip(h2));
+            
+            // check the topology
+            
+            graph.follow_edges(h1, false, [&](const handle_t& other) {
+                if (other == h2) {
+                    found1 = true;
+                }
+                else if (other == graph.flip(h2)) {
+                    found2 = true;
+                }
+                count1++;
+            });
+            graph.follow_edges(h1, true, [&](const handle_t& other) {
+                if (other == graph.flip(h2)) {
+                    found3 = true;
+                }
+                count2++;
+            });
+            graph.follow_edges(h2, false, [&](const handle_t& other) {
+                if (other == graph.flip(h1)) {
+                    found4 = true;
+                }
+                count3++;
+            });
+            graph.follow_edges(h2, true, [&](const handle_t& other) {
+                if (other == h1) {
+                    found5 = true;
+                }
+                else if (other == graph.flip(h1)) {
+                    found6 = true;
+                }
+                count4++;
+            });
+            assert(found1);
+            assert(found2);
+            assert(found3);
+            assert(found4);
+            assert(found5);
+            assert(found6);
+            assert(count1 == 2);
+            assert(count2 == 1);
+            assert(count3 == 1);
+            assert(count4 == 2);
+            found1 = found2 = found3 = found4 = found5 = found6 = false;
+            count1 = count2 = count3 = count4 = 0;
+            
+            // now another node and check to make sure that the edges are updated appropriately
+            
+            h2 = graph.apply_orientation(graph.flip(h2));
+            
+            graph.follow_edges(h1, false, [&](const handle_t& other) {
+                if (other == h2) {
+                    found1 = true;
+                }
+                else if (other == graph.flip(h2)) {
+                    found2 = true;
+                }
+                count1++;
+            });
+            graph.follow_edges(h1, true, [&](const handle_t& other) {
+                if (other == h2) {
+                    found3 = true;
+                }
+                count2++;
+            });
+            graph.follow_edges(h2, false, [&](const handle_t& other) {
+                if (other == h1) {
+                    found4 = true;
+                }
+                else if (other == graph.flip(h1)) {
+                    found5 = true;
+                }
+                count3++;
+            });
+            graph.follow_edges(h2, true, [&](const handle_t& other) {
+                if (other == h1) {
+                    found6 = true;
+                }
+                count4++;
+            });
+            assert(found1);
+            assert(found2);
+            assert(found3);
+            assert(found4);
+            assert(found5);
+            assert(found6);
+            assert(count1 == 2);
+            assert(count2 == 1);
+            assert(count3 == 2);
+            assert(count4 == 1);
+        }
+    }
+    
+    cerr << "DeletableHandleGraph tests successful!" << endl;
+}
+
+void test_mutable_path_handle_graphs() {
+    
+    vector<MutablePathDeletableHandleGraph*> implementations;
+    
+    PackedGraph pg;
+    implementations.push_back(&pg);
+    
+    HashGraph hg;
+    implementations.push_back(&hg);
+    
+    ODGI og;
+    implementations.push_back(&og);
+    
+    for (MutablePathDeletableHandleGraph* implementation : implementations) {
+        
+        MutablePathDeletableHandleGraph& graph = *implementation;
+        
+        auto check_path = [&](const path_handle_t& p, const vector<handle_t>& steps) {
+            
+            assert(graph.get_step_count(p) == steps.size());
+            
+            step_handle_t step = graph.path_begin(p);
+            for (int i = 0; i < steps.size(); i++) {
+                
+                assert(graph.get_path_handle_of_step(step) == p);
+                assert(graph.get_handle_of_step(step) == steps[i]);
+                
+                if (graph.get_is_circular(p)) {
+                    assert(graph.has_next_step(step));
+                    assert(graph.has_previous_step(step));
+                }
+                else {
+                    assert(graph.has_next_step(step) == i + 1 < steps.size());
+                    assert(graph.has_previous_step(step) == i > 0);
+                }
+                
+                step = graph.get_next_step(step);
+            }
+            
+            if (graph.get_is_circular(p) && !graph.is_empty(p)) {
+                assert(step == graph.path_begin(p));
+            }
+            else {
+                assert(step == graph.path_end(p));
+            }
+            
+            step = graph.path_back(p);
+            
+            for (int i = steps.size() - 1; i >= 0; i--) {
+                
+                assert(graph.get_path_handle_of_step(step) == p);
+                assert(graph.get_handle_of_step(step) == steps[i]);
+                
+                if (graph.get_is_circular(p)) {
+                    assert(graph.has_next_step(step));
+                    assert(graph.has_previous_step(step));
+                }
+                else {
+                    assert(graph.has_next_step(step) == i + 1 < steps.size());
+                    assert(graph.has_previous_step(step) == i > 0);
+                }
+                
+                step = graph.get_previous_step(step);
+            }
+            
+            if (graph.get_is_circular(p) && !graph.is_empty(p)) {
+                assert(step == graph.path_back(p));
+            }
+            else {
+                assert(step == graph.path_front_end(p));
+            }
+        };
+        
+        auto check_flips = [&](const path_handle_t& p, const vector<handle_t>& steps) {
+            auto flipped = steps;
+            for (size_t i = 0; i < steps.size(); i++) {
+                graph.apply_orientation(graph.flip(graph.forward(flipped[i])));
+                flipped[i] = graph.flip(flipped[i]);
+                check_path(p, flipped);
+                
+                graph.apply_orientation(graph.flip(graph.forward(flipped[i])));
+                flipped[i] = graph.flip(flipped[i]);
+                check_path(p, flipped);
+            }
+        };
+        
+        handle_t h1 = graph.create_handle("AC");
+        handle_t h2 = graph.create_handle("CAGTGA");
+        handle_t h3 = graph.create_handle("GT");
+        
+        graph.create_edge(h1, h2);
+        graph.create_edge(h2, h3);
+        graph.create_edge(h1, graph.flip(h2));
+        graph.create_edge(graph.flip(h2), h3);
+        
+        assert(!graph.has_path("1"));
+        assert(graph.get_path_count() == 0);
+        
+        path_handle_t p1 = graph.create_path_handle("1");
+        
+        assert(graph.has_path("1"));
+        assert(graph.get_path_count() == 1);
+        assert(graph.get_path_handle("1") == p1);
+        assert(graph.get_path_name(p1) == "1");
+        assert(graph.get_step_count(p1) == 0);
+        assert(graph.is_empty(p1));
+        
+        graph.append_step(p1, h1);
+        
+        assert(graph.get_step_count(p1) == 1);
+        assert(!graph.is_empty(p1));
+        
+        graph.append_step(p1, h2);
+        graph.append_step(p1, h3);
+        
+        assert(graph.get_step_count(p1) == 3);
+        
+        // graph can traverse a path
+        check_path(p1, {h1, h2, h3});
+        
+        // graph preserves paths when reversing nodes
+        check_flips(p1, {h1, h2, h3});
+        
+        // make a circular path
+        path_handle_t p2 = graph.create_path_handle("2", true);
+        assert(graph.get_path_count() == 2);
+        
+        graph.append_step(p2, h1);
+        graph.append_step(p2, graph.flip(h2));
+        graph.append_step(p2, h3);
+        
+        check_path(p2, {h1, graph.flip(h2), h3});
+        
+        // graph can query steps of a node on paths
+        
+        bool found1 = false, found2 = false;
+        vector<step_handle_t> steps = graph.steps_of_handle(h1);
+        for (auto& step : steps) {
+            if (graph.get_path_handle_of_step(step) == p1 &&
+                graph.get_handle_of_step(step) == h1) {
+                found1 = true;
+            }
+            else if (graph.get_path_handle_of_step(step) == p2 &&
+                     graph.get_handle_of_step(step) == h1) {
+                found2 = true;
+            }
+            else {
+                assert(false);
+            }
+        }
+        assert(found1);
+        assert(found2);
+        found1 = found2 = false;
+        
+        steps = graph.steps_of_handle(h1, true);
+        for (auto& step : steps) {
+            if (graph.get_path_handle_of_step(step) == p1 &&
+                graph.get_handle_of_step(step) == h1) {
+                found1 = true;
+            }
+            else if (graph.get_path_handle_of_step(step) == p2 &&
+                     graph.get_handle_of_step(step) == h1) {
+                found2 = true;
+            }
+            else {
+                assert(false);
+            }
+        }
+        assert(found1);
+        assert(found2);
+        found1 = found2 = false;
+        
+        steps = graph.steps_of_handle(graph.flip(h1), true);
+        for (auto& step : steps) {
+            assert(false);
+        }
+        
+        steps = graph.steps_of_handle(h2, true);
+        for (auto& step : steps) {
+            if (graph.get_path_handle_of_step(step) == p1 &&
+                graph.get_handle_of_step(step) == h2) {
+                found1 = true;
+            }
+            else {
+                assert(false);
+            }
+        }
+        steps = graph.steps_of_handle(graph.flip(h2), true);
+        for (auto& step : steps) {
+            if (graph.get_path_handle_of_step(step) == p2 &&
+                graph.get_handle_of_step(step) == graph.flip(h2)) {
+                found2 = true;
+            }
+            else {
+                assert(false);
+            }
+        }
+        assert(found1);
+        assert(found2);
+        found1 = found2 = false;
+        
+        vector<handle_t> segments = graph.divide_handle(h2, {size_t(2), size_t(4)});
+        
+        // graph preserves paths when dividing nodes
+        
+        check_path(p1, {h1, segments[0], segments[1], segments[2], h3});
+        check_path(p2, {h1, graph.flip(segments[2]), graph.flip(segments[1]), graph.flip(segments[0]), h3});
+        
+        path_handle_t p3 = graph.create_path_handle("3");
+        graph.append_step(p3, h1);
+        graph.append_step(p3, segments[0]);
+        
+        assert(graph.has_path("3"));
+        assert(graph.get_path_count() == 3);
+        
+        // graph can toggle circularity
+        
+        graph.for_each_path_handle([&](const path_handle_t& p) {
+            
+            vector<handle_t> steps;
+            
+            for (handle_t h : graph.scan_path(p)) {
+                steps.push_back(h);
+            }
+            
+            bool starting_circularity = graph.get_is_circular(p);
+            
+            // make every transition occur
+            for (bool circularity : {true, true, false, false, true}) {
+                graph.set_circularity(p, circularity);
+                assert(graph.get_is_circular(p) == circularity);
+                check_path(p, steps);
+            }
+            
+            graph.set_circularity(p, starting_circularity);
+        });
+        
+        // graph can destroy paths
+        
+        graph.destroy_path(p3);
+        
+        assert(!graph.has_path("3"));
+        assert(graph.get_path_count() == 2);
+        
+        bool found3 = false;
+        
+        graph.for_each_path_handle([&](const path_handle_t& p) {
+            if (graph.get_path_name(p) == "1") {
+                found1 = true;
+            }
+            else if (graph.get_path_name(p) == "2") {
+                found2 = true;
+            }
+            else if (graph.get_path_name(p) == "3") {
+                found3 = true;
+            }
+            else {
+                assert(false);
+            }
+        });
+        
+        assert(found1);
+        assert(found2);
+        assert(!found3);
+        
+        // check flips to see if membership records are still functional
+        check_flips(p1, {h1, segments[0], segments[1], segments[2], h3});
+        check_flips(p2, {h1, graph.flip(segments[2]), graph.flip(segments[1]), graph.flip(segments[0]), h3});
+        
+        graph.destroy_path(p1);
+        
+        assert(!graph.has_path("1"));
+        assert(graph.get_path_count() == 1);
+        
+        found1 = found2 = found3 = false;
+        
+        graph.for_each_path_handle([&](const path_handle_t& p) {
+            if (graph.get_path_name(p) == "1") {
+                found1 = true;
+            }
+            else if (graph.get_path_name(p) == "2") {
+                found2 = true;
+            }
+            else if (graph.get_path_name(p) == "3") {
+                found3 = true;
+            }
+            else {
+                assert(false);
+            }
+        });
+        
+        assert(!found1);
+        assert(found2);
+        assert(!found3);
+        
+        // check flips to see if membership records are still functional
+        check_flips(p2, {h1, graph.flip(segments[2]), graph.flip(segments[1]), graph.flip(segments[0]), h3});
+        
+        // make a path to rewrite
+        path_handle_t p4 = graph.create_path_handle("4");
+        graph.prepend_step(p4, h3);
+        graph.prepend_step(p4, segments[2]);
+        graph.prepend_step(p4, segments[1]);
+        graph.prepend_step(p4, segments[0]);
+        graph.prepend_step(p4, h1);
+        
+        check_flips(p4, {h1, segments[0], segments[1], segments[2], h3});
+        
+        auto check_rewritten_segment = [&](const pair<step_handle_t, step_handle_t>& new_segment,
+                                           const vector<handle_t>& steps) {
+            int i = 0;
+            for (auto step = new_segment.first; step != new_segment.second; step = graph.get_next_step(step)) {
+                assert(graph.get_handle_of_step(step) == steps[i]);
+                i++;
+            }
+            assert(i == steps.size());
+        };
+        
+        // rewrite the middle portion of a path
+        
+        step_handle_t s1 = graph.get_next_step(graph.path_begin(p4));
+        step_handle_t s2 = graph.get_next_step(graph.get_next_step(graph.get_next_step(s1)));
+        
+        auto new_segment = graph.rewrite_segment(s1, s2, {graph.flip(segments[2]), graph.flip(segments[1]), graph.flip(segments[0])});
+        
+        check_flips(p4, {h1, graph.flip(segments[2]), graph.flip(segments[1]), graph.flip(segments[0]), h3});
+        check_rewritten_segment(new_segment, {graph.flip(segments[2]), graph.flip(segments[1]), graph.flip(segments[0])});
+        
+        // rewrite around the end of a circular path to delete
+        
+        graph.create_edge(h3, h1);
+        graph.create_edge(segments[2], segments[0]);
+        graph.set_circularity(p4, true);
+        
+        s1 = graph.get_previous_step(graph.path_begin(p4));
+        s2 = graph.get_next_step(graph.path_begin(p4));
+        
+        new_segment = graph.rewrite_segment(s1, s2, vector<handle_t>());
+        
+        check_flips(p4, {graph.flip(segments[2]), graph.flip(segments[1]), graph.flip(segments[0])});
+        check_rewritten_segment(new_segment, vector<handle_t>());
+        
+        // add into an empty slot
+        
+        new_segment = graph.rewrite_segment(new_segment.first, new_segment.second, {graph.flip(h1), graph.flip(h3)});
+        
+        check_flips(p4, {graph.flip(h1), graph.flip(h3), graph.flip(segments[2]), graph.flip(segments[1]), graph.flip(segments[0])});
+        check_rewritten_segment(new_segment, {graph.flip(h1), graph.flip(h3)});
+        
+    }
+    
+    cerr << "MutablePathDeletableHandleGraph tests successful!" << endl;
+}
+
+int main(void) {
+    
+    test_deletable_handle_graphs();
+    test_mutable_path_handle_graphs();
+    
+}

--- a/src/test_libbdsg.cpp
+++ b/src/test_libbdsg.cpp
@@ -38,7 +38,7 @@ void test_deletable_handle_graphs() {
         implementations.push_back(&hg);
 
         ODGI og;
-        implementations.push_back(&og);
+        //implementations.push_back(&og);
         
         // And test them
         
@@ -1082,7 +1082,7 @@ void test_deletable_handle_graphs() {
         implementations.push_back(&hg);
         
         ODGI og;
-        implementations.push_back(&og);
+        //implementations.push_back(&og);
         
         for (DeletableHandleGraph* implementation : implementations) {
             
@@ -1283,12 +1283,11 @@ void test_mutable_path_handle_graphs() {
     implementations.push_back(&hg);
     
     ODGI og;
-    implementations.push_back(&og);
+    //implementations.push_back(&og);
     
     for (MutablePathDeletableHandleGraph* implementation : implementations) {
         
         auto check_path = [&](MutablePathDeletableHandleGraph& graph, const path_handle_t& p, const vector<handle_t>& steps) {
-            
             assert(graph.get_step_count(p) == steps.size());
             
             step_handle_t step = graph.path_begin(p);
@@ -1344,6 +1343,7 @@ void test_mutable_path_handle_graphs() {
         };
         
         auto check_flips = [&](MutablePathDeletableHandleGraph& graph, const path_handle_t& p, const vector<handle_t>& steps) {
+
             auto flipped = steps;
             for (size_t i = 0; i < steps.size(); i++) {
                 graph.apply_orientation(graph.flip(graph.forward(flipped[i])));
@@ -1923,7 +1923,6 @@ void test_packed_deque() {
 void test_packed_graph() {
     
     auto check_path = [&](MutablePathDeletableHandleGraph& graph, const path_handle_t& p, const vector<handle_t>& steps) {
-        
         assert(graph.get_step_count(p) == steps.size());
         
         step_handle_t step = graph.path_begin(p);
@@ -1979,6 +1978,7 @@ void test_packed_graph() {
     };
     
     auto check_flips = [&](MutablePathDeletableHandleGraph& graph, const path_handle_t& p, const vector<handle_t>& steps) {
+
         auto flipped = steps;
         for (size_t i = 0; i < steps.size(); i++) {
             graph.apply_orientation(graph.flip(graph.forward(flipped[i])));
@@ -2384,6 +2384,9 @@ void test_path_position_overlays() {
     ODGI og;
     
     vector<MutablePathDeletableHandleGraph*> implementations;
+    implementations.push_back(&pg);
+    implementations.push_back(&hg);
+    //implementations.push_back(&og);
     
     for (MutablePathDeletableHandleGraph* implementation : implementations) {
         
@@ -2519,8 +2522,8 @@ int main(void) {
     test_packed_vector();
     test_paged_vector();
     test_packed_deque();
-    test_packed_graph();
     test_deletable_handle_graphs();
     test_mutable_path_handle_graphs();
+    test_packed_graph();
     
 }

--- a/src/test_libbdsg.cpp
+++ b/src/test_libbdsg.cpp
@@ -2489,14 +2489,14 @@ void test_path_position_overlays() {
             assert(overlay.get_step_at_position(p2, 4) == overlay.path_end(p2));
             
             handle_t h2_flip = overlay.apply_orientation(overlay.flip(h2));
-            assert(overlay.get_handle_of_step(overlay.get_step_at_position(p1, 3)) == h2_flip);
+            assert(overlay.get_handle_of_step(overlay.get_step_at_position(p1, 3)) == overlay.flip(h2_flip));
             
             vector<size_t> offs_1{1};
             auto parts_1 = overlay.divide_handle(overlay.flip(h1), offs_1);
             assert(overlay.get_handle_of_step(overlay.get_step_at_position(p1, 0)) == overlay.flip(parts_1[1]));
             assert(overlay.get_handle_of_step(overlay.get_step_at_position(p1, 1)) == overlay.flip(parts_1[1]));
             assert(overlay.get_handle_of_step(overlay.get_step_at_position(p1, 2)) == overlay.flip(parts_1[0]));
-            assert(overlay.get_handle_of_step(overlay.get_step_at_position(p1, 3)) == h2_flip);
+            assert(overlay.get_handle_of_step(overlay.get_step_at_position(p1, 3)) == overlay.flip(h2_flip));
             assert(overlay.get_handle_of_step(overlay.get_step_at_position(p2, 0)) == overlay.flip(parts_1[1]));
             assert(overlay.get_handle_of_step(overlay.get_step_at_position(p2, 1)) == overlay.flip(parts_1[1]));
             assert(overlay.get_handle_of_step(overlay.get_step_at_position(p2, 2)) == overlay.flip(parts_1[0]));
@@ -2525,5 +2525,5 @@ int main(void) {
     test_deletable_handle_graphs();
     test_mutable_path_handle_graphs();
     test_packed_graph();
-    
+    test_path_position_overlays();
 }


### PR DESCRIPTION
I added the generic `PathPositionHandleGraph` overlays that I've been talking about forever. These turn any PathHandleGraph into a `PathPositionHandleGraph`. There's also an option to use a `MutablePathDeletableHandleGraph`, which maintains the position interface on-line during graph edits.

The current implementation is not really optimized. The data structures are all very STL-ish. In the future, I'd like to implement a bit-packed version as well. The main obstacle is getting an associative array from the step_handle_t's, which generally don't form contiguous ranges of integers (since they're 128 bits, usually with a lot of dead space).

While I was writing unittests for these objects, I also ported over the unittests for HashGraph and PackedGraph from VG. They really should live here. The test file is a bit inelegant, but we can always improve it later (perhaps by bringing in catch.hpp?)

In doing so, I found that the current ODGI implementation does not pass these tests. I'll open that as a separate issue. I haven't looked into it.