### PR TITLE
add vectorizable overlay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ INSTALL_PREFIX?=/usr/local
 INSTALL_LIB_DIR=$(INSTALL_PREFIX)/lib
 INSTALL_INC_DIR=$(INSTALL_PREFIX)/include
 
-OBJS:=$(OBJ_DIR)/eades_algorithm.o $(OBJ_DIR)/hash_graph.o $(OBJ_DIR)/is_single_stranded.o $(OBJ_DIR)/node.o $(OBJ_DIR)/odgi.o $(OBJ_DIR)/packed_graph.o $(OBJ_DIR)/packed_structs.o $(OBJ_DIR)/path_position_overlays.o $(OBJ_DIR)/split_strand_graph.o $(OBJ_DIR)/utility.o
+OBJS:=$(OBJ_DIR)/eades_algorithm.o $(OBJ_DIR)/hash_graph.o $(OBJ_DIR)/is_single_stranded.o $(OBJ_DIR)/node.o $(OBJ_DIR)/odgi.o $(OBJ_DIR)/packed_graph.o $(OBJ_DIR)/packed_structs.o $(OBJ_DIR)/path_position_overlays.o $(OBJ_DIR)/vectorizable_overlays.o $(OBJ_DIR)/split_strand_graph.o $(OBJ_DIR)/utility.o
 
 CXXFLAGS :=-O3 -Werror=return-type -std=c++14 -ggdb -g -msse4.2 -I$(INC_DIR) $(CXXFLAGS)
 
@@ -49,7 +49,10 @@ $(OBJ_DIR)/packed_structs.o: $(SRC_DIR)/packed_structs.cpp $(INC_DIR)/bdsg/packe
 	$(CXX) $(CXXFLAGS) -c $(SRC_DIR)/packed_structs.cpp -o $(OBJ_DIR)/packed_structs.o 
 
 $(OBJ_DIR)/path_position_overlays.o: $(SRC_DIR)/path_position_overlays.cpp $(INC_DIR)/bdsg/path_position_overlays.hpp
-	$(CXX) $(CXXFLAGS) -c $(SRC_DIR)/path_position_overlays.cpp -o $(OBJ_DIR)/path_position_overlays.o 
+	$(CXX) $(CXXFLAGS) -c $(SRC_DIR)/path_position_overlays.cpp -o $(OBJ_DIR)/path_position_overlays.o
+
+$(OBJ_DIR)/vectorizable_overlays.o: $(SRC_DIR)/vectorizable_overlays.cpp $(INC_DIR)/bdsg/vectorizable_overlays.hpp
+	$(CXX) $(CXXFLAGS) -c $(SRC_DIR)/vectorizable_overlays.cpp -o $(OBJ_DIR)/vectorizable_overlays.o
 
 $(OBJ_DIR)/split_strand_graph.o: $(SRC_DIR)/split_strand_graph.cpp $(INC_DIR)/bdsg/split_strand_graph.hpp
 	$(CXX) $(CXXFLAGS) -c $(SRC_DIR)/split_strand_graph.cpp -o $(OBJ_DIR)/split_strand_graph.o 

--- a/include/bdsg/vectorizable_overlays.hpp
+++ b/include/bdsg/vectorizable_overlays.hpp
@@ -19,6 +19,7 @@
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/path_position_handle_graph.hpp>
 #include <handlegraph/expanding_overlay_graph.hpp>
+#include "handlegraph/util.hpp"
 
 namespace bdsg {
     
@@ -30,52 +31,52 @@ using namespace handlegraph;
  * by augmenting it with relatively simple data structures.
  *
  */
-class VectorizableOverlay : public VectorizableHandleGraph, public ExpandingOverlayGraph {
+class VectorizableOverlay : virtual public VectorizableHandleGraph, virtual public ExpandingOverlayGraph {
         
 public:
     
     VectorizableOverlay(const HandleGraph* graph);
     VectorizableOverlay();
-    ~VectorizableOverlay();
+    virtual ~VectorizableOverlay();
 
     ////////////////////////////////////////////////////////////////////////////
     // HandleGraph interface
     ////////////////////////////////////////////////////////////////////////////
     
     /// Method to check if a node exists by ID
-    bool has_node(nid_t node_id) const;
+    virtual bool has_node(nid_t node_id) const;
     
     /// Look up the handle for the node with the given ID in the given orientation
-    handle_t get_handle(const nid_t& node_id, bool is_reverse = false) const;
+    virtual  handle_t get_handle(const nid_t& node_id, bool is_reverse = false) const;
     
     /// Get the ID from a handle
-    nid_t get_id(const handle_t& handle) const;
+    virtual nid_t get_id(const handle_t& handle) const;
     
     /// Get the orientation of a handle
-    bool get_is_reverse(const handle_t& handle) const;
+    virtual  bool get_is_reverse(const handle_t& handle) const;
     
     /// Invert the orientation of a handle (potentially without getting its ID)
-    handle_t flip(const handle_t& handle) const;
+    virtual handle_t flip(const handle_t& handle) const;
     
     /// Get the length of a node
-    size_t get_length(const handle_t& handle) const;
+    virtual size_t get_length(const handle_t& handle) const;
     
     /// Get the sequence of a node, presented in the handle's local forward orientation.
-    string get_sequence(const handle_t& handle) const;
+    virtual string get_sequence(const handle_t& handle) const;
     
 private:
     
     /// Loop over all the handles to next/previous (right/left) nodes. Passes
     /// them to a callback which returns false to stop iterating and true to
     /// continue. Returns true if we finished and false if we stopped early.
-    bool follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const;
+    virtual bool follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const;
     
     /// Loop over all the nodes in the graph in their local forward
     /// orientations, in their internal stored order. Stop if the iteratee
     /// returns false. Can be told to run in parallel, in which case stopping
     /// after a false return value is on a best-effort basis and iteration
     /// order is not defined.
-    bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
+    virtual bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
     
 public:
     
@@ -83,32 +84,32 @@ public:
     /// = true) side of the given handle. The default implementation is O(n) in
     /// the number of edges returned, but graph implementations that track this
     /// information more efficiently can override this method.
-    size_t get_degree(const handle_t& handle, bool go_left) const;
+    virtual size_t get_degree(const handle_t& handle, bool go_left) const;
     
     /// Returns true if there is an edge that allows traversal from the left
     /// handle to the right handle. By default O(n) in the number of edges
     /// on left, but can be overridden with more efficient implementations.
-    bool has_edge(const handle_t& left, const handle_t& right) const;
+    virtual bool has_edge(const handle_t& left, const handle_t& right) const;
     
     /// Returns one base of a handle's sequence, in the orientation of the
     /// handle.
-    char get_base(const handle_t& handle, size_t index) const;
+    virtual char get_base(const handle_t& handle, size_t index) const;
     
     /// Returns a substring of a handle's sequence, in the orientation of the
     /// handle. If the indicated substring would extend beyond the end of the
     /// handle's sequence, the return value is truncated to the sequence's end.
-    std::string get_subsequence(const handle_t& handle, size_t index, size_t size) const;
+    virtual std::string get_subsequence(const handle_t& handle, size_t index, size_t size) const;
     
     /// Return the number of nodes in the graph
-    size_t get_node_count(void) const;
+    virtual size_t get_node_count(void) const;
     
     /// Return the smallest ID in the graph, or some smaller number if the
     /// smallest ID is unavailable. Return value is unspecified if the graph is empty.
-    nid_t min_node_id(void) const;
+    virtual nid_t min_node_id(void) const;
     
     /// Return the largest ID in the graph, or some larger number if the
     /// largest ID is unavailable. Return value is unspecified if the graph is empty.
-    nid_t max_node_id(void) const;
+    virtual nid_t max_node_id(void) const;
     
     ////////////////////////////////////////////////////////////////////////////
     // Vectorizable handle interface
@@ -132,12 +133,12 @@ public:
      * Returns the handle in the underlying graph that corresponds to a handle in the
      * overlay
      */
-    handle_t get_underlying_handle(const handle_t& handle) const;
+    virtual handle_t get_underlying_handle(const handle_t& handle) const;
     
 protected:
     
     /// Construct the index over path positions
-    void index_nodes_and_edges();
+    virtual void index_nodes_and_edges();
     
     /// The graph we're overlaying
     const HandleGraph* graph = nullptr;
@@ -159,11 +160,144 @@ protected:
     sdsl::bit_vector::select_1_type s_bv_select;
     
     /// Getter for graph
-    inline const HandleGraph* get_graph() const {
+    virtual inline const HandleGraph* get_graph() const {
         return graph;
     }
 };
+
+class PathVectorizableOverlay : virtual public VectorizableOverlay, virtual public PathHandleGraph {
+
+public:
     
+    PathVectorizableOverlay(const PathHandleGraph* path_graph);
+    PathVectorizableOverlay();
+    virtual ~PathVectorizableOverlay();
+
+public:
+
+    using VectorizableOverlay::has_node;
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Path handle interface that needs to be implemented
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Returns the number of paths stored in the graph
+    virtual size_t get_path_count() const;
+    
+    /// Determine if a path name exists and is legal to get a path handle for.
+    virtual bool has_path(const std::string& path_name) const;
+    
+    /// Look up the path handle for the given path name.
+    /// The path with that name must exist.
+    virtual path_handle_t get_path_handle(const std::string& path_name) const;
+    
+    /// Look up the name of a path from a handle to it
+    virtual std::string get_path_name(const path_handle_t& path_handle) const;
+    
+    /// Look up whether a path is circular
+    virtual bool get_is_circular(const path_handle_t& path_handle) const;
+    
+    /// Returns the number of node steps in the path
+    virtual size_t get_step_count(const path_handle_t& path_handle) const;
+    
+    /// Get a node handle (node ID and orientation) from a handle to an step on a path
+    virtual handle_t get_handle_of_step(const step_handle_t& step_handle) const;
+    
+    /// Returns a handle to the path that an step is on
+    virtual path_handle_t get_path_handle_of_step(const step_handle_t& step_handle) const;
+    
+    /// Get a handle to the first step, which will be an arbitrary step in a circular path
+    /// that we consider "first" based on our construction of the path. If the path is empty,
+    /// then the implementation must return the same value as path_end().
+    virtual step_handle_t path_begin(const path_handle_t& path_handle) const;
+    
+    /// Get a handle to a fictitious position past the end of a path. This position is
+    /// returned by get_next_step for the final step in a path in a non-circular path.
+    /// Note: get_next_step will *NEVER* return this value for a circular path.
+    virtual step_handle_t path_end(const path_handle_t& path_handle) const;
+    
+    /// Get a handle to the last step, which will be an arbitrary step in a circular path that
+    /// we consider "last" based on our construction of the path. If the path is empty
+    /// then the implementation must return the same value as path_front_end().
+    virtual step_handle_t path_back(const path_handle_t& path_handle) const;
+    
+    /// Get a handle to a fictitious position before the beginning of a path. This position is
+    /// return by get_previous_step for the first step in a path in a non-circular path.
+    /// Note: get_previous_step will *NEVER* return this value for a circular path.
+    virtual step_handle_t path_front_end(const path_handle_t& path_handle) const;
+
+    /// Returns true if the step is not the last step in a non-circular path.
+    virtual bool has_next_step(const step_handle_t& step_handle) const;
+
+    /// Returns true if the step is not the first step in a non-circular path.
+    virtual bool has_previous_step(const step_handle_t& step_handle) const;
+    
+    /// Returns a handle to the next step on the path. If the given step is the final step
+    /// of a non-circular path, this method has undefined behavior. In a circular path,
+    /// the "last" step will loop around to the "first" step.
+    virtual step_handle_t get_next_step(const step_handle_t& step_handle) const;
+    
+    /// Returns a handle to the previous step on the path. If the given step is the first
+    /// step of a non-circular path, this method has undefined behavior. In a circular path,
+    /// it will loop around from the "first" step (i.e. the one returned by path_begin) to
+    /// the "last" step.
+    virtual step_handle_t get_previous_step(const step_handle_t& step_handle) const;
+        
+protected:
+    
+    /// Execute a function on each path in the graph. If it returns false, stop
+    /// iteration. Returns true if we finished and false if we stopped early.
+    virtual bool for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const;
+    
+    /// Execute a function on each step of a handle in any path. If it
+    /// returns false, stop iteration. Returns true if we finished and false if
+    /// we stopped early.
+    virtual bool for_each_step_on_handle_impl(const handle_t& handle,
+        const std::function<bool(const step_handle_t&)>& iteratee) const;
+
+protected:
+    
+    /// Keep this around to avoid dynamic_casting this->graph every time we need path stuff
+    const PathHandleGraph* path_graph;
+};
+
+
+class PathPositionVectorizableOverlay : virtual public PathVectorizableOverlay, virtual public PathPositionHandleGraph {
+
+public:
+    
+    PathPositionVectorizableOverlay(const PathPositionHandleGraph* path_position_graph);
+    PathPositionVectorizableOverlay();
+    virtual ~PathPositionVectorizableOverlay();
+
+public:
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Path Position handle Interface that needs to be implemented
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// Returns the length of a path measured in bases of sequence.
+    virtual size_t get_path_length(const path_handle_t& path_handle) const;
+    
+    /// Returns the position along the path of the beginning of this step measured in
+    /// bases of sequence. In a circular path, positions start at the step returned by
+    /// path_begin().
+    virtual size_t get_position_of_step(const step_handle_t& step) const;
+    
+    /// Returns the step at this position, measured in bases of sequence starting at
+    /// the step returned by path_begin(). If the position is past the end of the
+    /// path, returns path_end().
+    virtual step_handle_t get_step_at_position(const path_handle_t& path,
+                                               const size_t& position) const;
+    
+protected:
+    
+    /// Keep this around to avoid dynamic_casting this->graph every time we need path stuff
+    const PathPositionHandleGraph* path_position_graph;
+};
+
+
+
 }
 
 #endif

--- a/include/bdsg/vectorizable_overlays.hpp
+++ b/include/bdsg/vectorizable_overlays.hpp
@@ -19,7 +19,6 @@
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/path_position_handle_graph.hpp>
 #include <handlegraph/expanding_overlay_graph.hpp>
-#include "handlegraph/util.hpp"
 
 namespace bdsg {
     
@@ -141,7 +140,7 @@ protected:
     virtual void index_nodes_and_edges();
     
     /// The graph we're overlaying
-    const HandleGraph* graph = nullptr;
+    const HandleGraph* underlying_graph = nullptr;
 
     /// Edge to rank
     // (I can't get it the pair_hash_map to compile with handle_t's, so using integers
@@ -159,13 +158,9 @@ protected:
     sdsl::rank_support_v<1> s_bv_rank;
     sdsl::bit_vector::select_1_type s_bv_select;
     
-    /// Getter for graph
-    virtual inline const HandleGraph* get_graph() const {
-        return graph;
-    }
 };
 
-class PathVectorizableOverlay : virtual public VectorizableOverlay, virtual public PathHandleGraph {
+class PathVectorizableOverlay : public VectorizableOverlay, virtual public PathHandleGraph {
 
 public:
     
@@ -175,8 +170,6 @@ public:
 
 public:
 
-    using VectorizableOverlay::has_node;
-    
     ////////////////////////////////////////////////////////////////////////////
     // Path handle interface that needs to be implemented
     ////////////////////////////////////////////////////////////////////////////
@@ -257,12 +250,12 @@ protected:
 
 protected:
     
-    /// Keep this around to avoid dynamic_casting this->graph every time we need path stuff
-    const PathHandleGraph* path_graph;
+    /// Keep this around to avoid dynamic_casting this->underlying_graph every time we need path stuff
+    const PathHandleGraph* underlying_path_graph = nullptr;
 };
 
 
-class PathPositionVectorizableOverlay : virtual public PathVectorizableOverlay, virtual public PathPositionHandleGraph {
+class PathPositionVectorizableOverlay : public PathVectorizableOverlay, virtual public PathPositionHandleGraph {
 
 public:
     
@@ -292,8 +285,8 @@ public:
     
 protected:
     
-    /// Keep this around to avoid dynamic_casting this->graph every time we need path stuff
-    const PathPositionHandleGraph* path_position_graph;
+    /// Keep this around to avoid dynamic_casting this->underlying_graph every time we need path stuff
+    const PathPositionHandleGraph* underlying_path_position_graph = nullptr;
 };
 
 

--- a/include/bdsg/vectorizable_overlays.hpp
+++ b/include/bdsg/vectorizable_overlays.hpp
@@ -1,0 +1,169 @@
+//
+//  vectorizable_overlays.hpp
+//  
+//  Contains generic overlays for HandleGraph's that add the
+//  VectorizableHandleGraph interface methods for querying steps by base-pair
+//  position.
+//
+
+#ifndef BDSG_VECTORIZABLE_OVERLAYS_HPP_INCLUDED
+#define BDSG_VECTORIZABLE_OVERLAYS_HPP_INCLUDED
+
+#include <unordered_map>
+#include <map>
+
+#include "sdsl/bit_vectors.hpp"
+
+#include "bdsg/hash_map.hpp"
+
+#include <handlegraph/handle_graph.hpp>
+#include <handlegraph/path_position_handle_graph.hpp>
+#include <handlegraph/expanding_overlay_graph.hpp>
+
+namespace bdsg {
+    
+using namespace std;
+using namespace handlegraph;
+
+/*
+ * An overlay that adds the VectorizableHandleGraph interface to a HandleGraph
+ * by augmenting it with relatively simple data structures.
+ *
+ */
+class VectorizableOverlay : public VectorizableHandleGraph, public ExpandingOverlayGraph {
+        
+public:
+    
+    VectorizableOverlay(const HandleGraph* graph);
+    VectorizableOverlay();
+    ~VectorizableOverlay();
+
+    ////////////////////////////////////////////////////////////////////////////
+    // HandleGraph interface
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Method to check if a node exists by ID
+    bool has_node(nid_t node_id) const;
+    
+    /// Look up the handle for the node with the given ID in the given orientation
+    handle_t get_handle(const nid_t& node_id, bool is_reverse = false) const;
+    
+    /// Get the ID from a handle
+    nid_t get_id(const handle_t& handle) const;
+    
+    /// Get the orientation of a handle
+    bool get_is_reverse(const handle_t& handle) const;
+    
+    /// Invert the orientation of a handle (potentially without getting its ID)
+    handle_t flip(const handle_t& handle) const;
+    
+    /// Get the length of a node
+    size_t get_length(const handle_t& handle) const;
+    
+    /// Get the sequence of a node, presented in the handle's local forward orientation.
+    string get_sequence(const handle_t& handle) const;
+    
+private:
+    
+    /// Loop over all the handles to next/previous (right/left) nodes. Passes
+    /// them to a callback which returns false to stop iterating and true to
+    /// continue. Returns true if we finished and false if we stopped early.
+    bool follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const;
+    
+    /// Loop over all the nodes in the graph in their local forward
+    /// orientations, in their internal stored order. Stop if the iteratee
+    /// returns false. Can be told to run in parallel, in which case stopping
+    /// after a false return value is on a best-effort basis and iteration
+    /// order is not defined.
+    bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
+    
+public:
+    
+    /// Get the number of edges on the right (go_left = false) or left (go_left
+    /// = true) side of the given handle. The default implementation is O(n) in
+    /// the number of edges returned, but graph implementations that track this
+    /// information more efficiently can override this method.
+    size_t get_degree(const handle_t& handle, bool go_left) const;
+    
+    /// Returns true if there is an edge that allows traversal from the left
+    /// handle to the right handle. By default O(n) in the number of edges
+    /// on left, but can be overridden with more efficient implementations.
+    bool has_edge(const handle_t& left, const handle_t& right) const;
+    
+    /// Returns one base of a handle's sequence, in the orientation of the
+    /// handle.
+    char get_base(const handle_t& handle, size_t index) const;
+    
+    /// Returns a substring of a handle's sequence, in the orientation of the
+    /// handle. If the indicated substring would extend beyond the end of the
+    /// handle's sequence, the return value is truncated to the sequence's end.
+    std::string get_subsequence(const handle_t& handle, size_t index, size_t size) const;
+    
+    /// Return the number of nodes in the graph
+    size_t get_node_count(void) const;
+    
+    /// Return the smallest ID in the graph, or some smaller number if the
+    /// smallest ID is unavailable. Return value is unspecified if the graph is empty.
+    nid_t min_node_id(void) const;
+    
+    /// Return the largest ID in the graph, or some larger number if the
+    /// largest ID is unavailable. Return value is unspecified if the graph is empty.
+    nid_t max_node_id(void) const;
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Vectorizable handle interface
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// Return the start position of the node in a (possibly implict) sorted array
+    /// constructed from the concatenation of the node sequences
+    virtual size_t node_vector_offset(const nid_t& node_id) const;
+
+    /// Return the node overlapping the given offset in the implicit node vector
+    virtual nid_t node_at_vector_offset(const size_t& offset) const;
+
+    /// Return a unique index among edges in the graph
+    virtual size_t edge_index(const edge_t& edge) const;
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Expanding overlay interface
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /**
+     * Returns the handle in the underlying graph that corresponds to a handle in the
+     * overlay
+     */
+    handle_t get_underlying_handle(const handle_t& handle) const;
+    
+protected:
+    
+    /// Construct the index over path positions
+    void index_nodes_and_edges();
+    
+    /// The graph we're overlaying
+    const HandleGraph* graph = nullptr;
+
+    /// Edge to rank
+    // (I can't get it the pair_hash_map to compile with handle_t's, so using integers
+    //  directly until I ca figure it out)
+    pair_hash_map<pair<uint64_t, uint64_t>, size_t> edge_to_rank;
+    
+    /// Rank to node
+    vector<nid_t> rank_to_node;
+
+    /// Node to rank (make no assumptions about id-space so use map instead of vector)
+    hash_map<nid_t, size_t> node_to_rank;
+
+    /// Map between global sequence position and node rank
+    sdsl::bit_vector s_bv;
+    sdsl::rank_support_v<1> s_bv_rank;
+    sdsl::bit_vector::select_1_type s_bv_select;
+    
+    /// Getter for graph
+    inline const HandleGraph* get_graph() const {
+        return graph;
+    }
+};
+    
+}
+
+#endif

--- a/src/vectorizable_overlays.cpp
+++ b/src/vectorizable_overlays.cpp
@@ -1,0 +1,135 @@
+#include "bdsg/vectorizable_overlays.hpp"
+#include "handlegraph/util.hpp"
+
+namespace bdsg {
+
+VectorizableOverlay::VectorizableOverlay(const HandleGraph* graph) : graph(graph) {
+    index_nodes_and_edges();
+}
+
+VectorizableOverlay::VectorizableOverlay() {
+        
+}
+    
+VectorizableOverlay::~VectorizableOverlay() {
+        
+}
+    
+bool VectorizableOverlay::has_node(nid_t node_id) const {
+    return get_graph()->has_node(node_id);
+}
+    
+handle_t VectorizableOverlay::get_handle(const nid_t& node_id, bool is_reverse) const {
+    return get_graph()->get_handle(node_id, is_reverse);
+}
+    
+nid_t VectorizableOverlay::get_id(const handle_t& handle) const {
+    return get_graph()->get_id(handle);
+}
+    
+bool VectorizableOverlay::get_is_reverse(const handle_t& handle) const {
+    return get_graph()->get_is_reverse(handle);
+}
+    
+handle_t VectorizableOverlay::flip(const handle_t& handle) const {
+    return get_graph()->flip(handle);
+}
+    
+size_t VectorizableOverlay::get_length(const handle_t& handle) const {
+    return get_graph()->get_length(handle);
+}
+    
+string VectorizableOverlay::get_sequence(const handle_t& handle) const {
+    return get_graph()->get_sequence(handle);
+}
+    
+bool VectorizableOverlay::follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const {
+    return get_graph()->follow_edges(handle, go_left, iteratee);
+}
+    
+bool VectorizableOverlay::for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel) const {
+    return get_graph()->for_each_handle(iteratee, parallel);
+}
+    
+size_t VectorizableOverlay::get_degree(const handle_t& handle, bool go_left) const {
+    return get_graph()->get_degree(handle, go_left);
+}
+    
+bool VectorizableOverlay::has_edge(const handle_t& left, const handle_t& right) const {
+    return get_graph()->has_edge(left, right);
+}
+    
+char VectorizableOverlay::get_base(const handle_t& handle, size_t index) const {
+    return get_graph()->get_base(handle, index);
+}
+    
+std::string VectorizableOverlay::get_subsequence(const handle_t& handle, size_t index, size_t size) const {
+    return get_graph()->get_subsequence(handle, index, size);
+}
+    
+size_t VectorizableOverlay::get_node_count(void) const {
+    return get_graph()->get_node_count();
+}
+    
+nid_t VectorizableOverlay::min_node_id(void) const {
+    return get_graph()->min_node_id();
+}
+    
+nid_t VectorizableOverlay::max_node_id(void) const {
+    return get_graph()->max_node_id();
+}
+
+// this gives a 0-based offset of the node
+size_t VectorizableOverlay::node_vector_offset(const nid_t& node_id) const {
+    return s_bv_select(node_to_rank.at(node_id));
+}
+
+// this expects a 1-based offset of the node
+nid_t VectorizableOverlay::node_at_vector_offset(const size_t& offset) const {
+    return rank_to_node.at(s_bv_rank(offset));
+}
+
+size_t VectorizableOverlay::edge_index(const edge_t& edge) const {
+    return edge_to_rank.at(make_pair(as_integer(edge.first), as_integer(edge.second)));
+}
+    
+handle_t VectorizableOverlay::get_underlying_handle(const handle_t& handle) const {
+    return handle;
+}
+    
+void VectorizableOverlay::index_nodes_and_edges() {
+
+    // index the edges
+    //edge_to_rank.clear();
+    size_t edge_rank = 1;
+    get_graph()->for_each_edge([&](const edge_t& edge) {
+            edge_to_rank[make_pair(as_integer(edge.first), as_integer(edge.second))] = edge_rank++;
+        });
+
+    // index our node ranks
+    rank_to_node.clear();
+    node_to_rank.clear();    
+    rank_to_node.resize(get_node_count() + 1);
+    node_to_rank.reserve(get_node_count());
+    size_t seq_length = 0;
+    size_t node_rank = 1;
+    get_graph()->for_each_handle([&](const handle_t& handle) {
+            seq_length += get_graph()->get_length(handle);
+            nid_t node_id = get_graph()->get_id(handle);
+            rank_to_node[node_rank] = node_id;
+            node_to_rank[node_id] = node_rank;
+            ++node_rank;
+        });
+
+    // index our node offsets
+    sdsl::util::assign(s_bv, sdsl::bit_vector(seq_length));
+    seq_length = 0;
+    for (node_rank = 1; node_rank < rank_to_node.size(); ++node_rank) {
+        s_bv[seq_length] = 1;
+        seq_length += get_graph()->get_length(get_graph()->get_handle(rank_to_node[node_rank]));
+    }
+    sdsl::util::assign(s_bv_rank, sdsl::rank_support_v<1>(&s_bv));
+    sdsl::util::assign(s_bv_select, sdsl::bit_vector::select_1_type(&s_bv));
+}
+    
+}

--- a/src/vectorizable_overlays.cpp
+++ b/src/vectorizable_overlays.cpp
@@ -131,5 +131,119 @@ void VectorizableOverlay::index_nodes_and_edges() {
     sdsl::util::assign(s_bv_rank, sdsl::rank_support_v<1>(&s_bv));
     sdsl::util::assign(s_bv_select, sdsl::bit_vector::select_1_type(&s_bv));
 }
+
+PathVectorizableOverlay::PathVectorizableOverlay(const PathHandleGraph* path_graph) :
+    VectorizableOverlay(path_graph),
+    path_graph(path_graph) {
+}
+
+PathVectorizableOverlay::PathVectorizableOverlay() {
+        
+}
     
+PathVectorizableOverlay::~PathVectorizableOverlay() {
+        
+}
+
+size_t PathVectorizableOverlay::get_path_count() const {
+    return path_graph->get_path_count();
+}
+    
+bool PathVectorizableOverlay::has_path(const std::string& path_name) const {
+    return path_graph->has_path(path_name);
+}
+    
+path_handle_t PathVectorizableOverlay::get_path_handle(const std::string& path_name) const {
+    return path_graph->get_path_handle(path_name);
+}
+    
+string PathVectorizableOverlay::get_path_name(const path_handle_t& path_handle) const {
+    return path_graph->get_path_name(path_handle);
+}
+    
+bool PathVectorizableOverlay::get_is_circular(const path_handle_t& path_handle) const {
+    return path_graph->get_is_circular(path_handle);
+}
+    
+size_t PathVectorizableOverlay::get_step_count(const path_handle_t& path_handle) const {
+    return path_graph->get_step_count(path_handle);
+}
+    
+handle_t PathVectorizableOverlay::get_handle_of_step(const step_handle_t& step_handle) const {
+    return path_graph->get_handle_of_step(step_handle);
+}
+    
+step_handle_t PathVectorizableOverlay::path_begin(const path_handle_t& path_handle) const {
+    return path_graph->path_begin(path_handle);
+}
+    
+step_handle_t PathVectorizableOverlay::path_end(const path_handle_t& path_handle) const {
+    return path_graph->path_end(path_handle);
+}
+    
+step_handle_t PathVectorizableOverlay::path_back(const path_handle_t& path_handle) const {
+    return path_graph->path_back(path_handle);
+}
+    
+step_handle_t PathVectorizableOverlay::path_front_end(const path_handle_t& path_handle) const {
+    return path_graph->path_front_end(path_handle);
+}
+    
+bool PathVectorizableOverlay::has_next_step(const step_handle_t& step_handle) const {
+    return path_graph->has_next_step(step_handle);
+}
+    
+bool PathVectorizableOverlay::has_previous_step(const step_handle_t& step_handle) const {
+    return path_graph->has_previous_step(step_handle);
+}
+    
+step_handle_t PathVectorizableOverlay::get_next_step(const step_handle_t& step_handle) const {
+    return path_graph->get_next_step(step_handle);
+}
+    
+step_handle_t PathVectorizableOverlay::get_previous_step(const step_handle_t& step_handle) const {
+    return path_graph->get_previous_step(step_handle);
+}
+    
+path_handle_t PathVectorizableOverlay::get_path_handle_of_step(const step_handle_t& step_handle) const {
+    return path_graph->get_path_handle_of_step(step_handle);
+}
+    
+bool PathVectorizableOverlay::for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const {
+    return path_graph->for_each_path_handle(iteratee);
+}
+    
+bool PathVectorizableOverlay::for_each_step_on_handle_impl(const handle_t& handle,
+                                                           const function<bool(const step_handle_t&)>& iteratee) const {
+    return path_graph->for_each_step_on_handle(handle, iteratee);
+}
+    
+
+PathPositionVectorizableOverlay::PathPositionVectorizableOverlay(const PathPositionHandleGraph* path_position_graph) :
+    PathVectorizableOverlay(path_position_graph),
+    path_position_graph(path_position_graph) {
+}
+
+PathPositionVectorizableOverlay::PathPositionVectorizableOverlay() {
+        
+}
+    
+PathPositionVectorizableOverlay::~PathPositionVectorizableOverlay() {
+        
+}
+
+size_t PathPositionVectorizableOverlay::get_path_length(const path_handle_t& path_handle) const {
+    return path_position_graph->get_path_length(path_handle);
+}
+
+size_t PathPositionVectorizableOverlay::get_position_of_step(const step_handle_t& step) const {
+    return path_position_graph->get_position_of_step(step);
+}
+    
+step_handle_t PathPositionVectorizableOverlay::get_step_at_position(const path_handle_t& path,
+                                                                    const size_t& position) const {
+    return path_position_graph->get_step_at_position(path, position);
+}
+
+
 }

--- a/src/vectorizable_overlays.cpp
+++ b/src/vectorizable_overlays.cpp
@@ -3,7 +3,8 @@
 
 namespace bdsg {
 
-VectorizableOverlay::VectorizableOverlay(const HandleGraph* graph) : graph(graph) {
+VectorizableOverlay::VectorizableOverlay(const HandleGraph* graph) : underlying_graph(graph) {
+    assert(underlying_graph != nullptr);
     index_nodes_and_edges();
 }
 
@@ -16,67 +17,67 @@ VectorizableOverlay::~VectorizableOverlay() {
 }
     
 bool VectorizableOverlay::has_node(nid_t node_id) const {
-    return get_graph()->has_node(node_id);
+    return underlying_graph->has_node(node_id);
 }
     
 handle_t VectorizableOverlay::get_handle(const nid_t& node_id, bool is_reverse) const {
-    return get_graph()->get_handle(node_id, is_reverse);
+    return underlying_graph->get_handle(node_id, is_reverse);
 }
     
 nid_t VectorizableOverlay::get_id(const handle_t& handle) const {
-    return get_graph()->get_id(handle);
+    return underlying_graph->get_id(handle);
 }
     
 bool VectorizableOverlay::get_is_reverse(const handle_t& handle) const {
-    return get_graph()->get_is_reverse(handle);
+    return underlying_graph->get_is_reverse(handle);
 }
     
 handle_t VectorizableOverlay::flip(const handle_t& handle) const {
-    return get_graph()->flip(handle);
+    return underlying_graph->flip(handle);
 }
     
 size_t VectorizableOverlay::get_length(const handle_t& handle) const {
-    return get_graph()->get_length(handle);
+    return underlying_graph->get_length(handle);
 }
     
 string VectorizableOverlay::get_sequence(const handle_t& handle) const {
-    return get_graph()->get_sequence(handle);
+    return underlying_graph->get_sequence(handle);
 }
     
 bool VectorizableOverlay::follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const {
-    return get_graph()->follow_edges(handle, go_left, iteratee);
+    return underlying_graph->follow_edges(handle, go_left, iteratee);
 }
     
 bool VectorizableOverlay::for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel) const {
-    return get_graph()->for_each_handle(iteratee, parallel);
+    return underlying_graph->for_each_handle(iteratee, parallel);
 }
     
 size_t VectorizableOverlay::get_degree(const handle_t& handle, bool go_left) const {
-    return get_graph()->get_degree(handle, go_left);
+    return underlying_graph->get_degree(handle, go_left);
 }
     
 bool VectorizableOverlay::has_edge(const handle_t& left, const handle_t& right) const {
-    return get_graph()->has_edge(left, right);
+    return underlying_graph->has_edge(left, right);
 }
     
 char VectorizableOverlay::get_base(const handle_t& handle, size_t index) const {
-    return get_graph()->get_base(handle, index);
+    return underlying_graph->get_base(handle, index);
 }
     
 std::string VectorizableOverlay::get_subsequence(const handle_t& handle, size_t index, size_t size) const {
-    return get_graph()->get_subsequence(handle, index, size);
+    return underlying_graph->get_subsequence(handle, index, size);
 }
     
 size_t VectorizableOverlay::get_node_count(void) const {
-    return get_graph()->get_node_count();
+    return underlying_graph->get_node_count();
 }
     
 nid_t VectorizableOverlay::min_node_id(void) const {
-    return get_graph()->min_node_id();
+    return underlying_graph->min_node_id();
 }
     
 nid_t VectorizableOverlay::max_node_id(void) const {
-    return get_graph()->max_node_id();
+    return underlying_graph->max_node_id();
 }
 
 // this gives a 0-based offset of the node
@@ -102,7 +103,7 @@ void VectorizableOverlay::index_nodes_and_edges() {
     // index the edges
     //edge_to_rank.clear();
     size_t edge_rank = 1;
-    get_graph()->for_each_edge([&](const edge_t& edge) {
+    underlying_graph->for_each_edge([&](const edge_t& edge) {
             edge_to_rank[make_pair(as_integer(edge.first), as_integer(edge.second))] = edge_rank++;
         });
 
@@ -113,9 +114,9 @@ void VectorizableOverlay::index_nodes_and_edges() {
     node_to_rank.reserve(get_node_count());
     size_t seq_length = 0;
     size_t node_rank = 1;
-    get_graph()->for_each_handle([&](const handle_t& handle) {
-            seq_length += get_graph()->get_length(handle);
-            nid_t node_id = get_graph()->get_id(handle);
+    underlying_graph->for_each_handle([&](const handle_t& handle) {
+            seq_length += underlying_graph->get_length(handle);
+            nid_t node_id = underlying_graph->get_id(handle);
             rank_to_node[node_rank] = node_id;
             node_to_rank[node_id] = node_rank;
             ++node_rank;
@@ -126,15 +127,17 @@ void VectorizableOverlay::index_nodes_and_edges() {
     seq_length = 0;
     for (node_rank = 1; node_rank < rank_to_node.size(); ++node_rank) {
         s_bv[seq_length] = 1;
-        seq_length += get_graph()->get_length(get_graph()->get_handle(rank_to_node[node_rank]));
+        seq_length += underlying_graph->get_length(underlying_graph->get_handle(rank_to_node[node_rank]));
     }
     sdsl::util::assign(s_bv_rank, sdsl::rank_support_v<1>(&s_bv));
     sdsl::util::assign(s_bv_select, sdsl::bit_vector::select_1_type(&s_bv));
 }
 
 PathVectorizableOverlay::PathVectorizableOverlay(const PathHandleGraph* path_graph) :
-    VectorizableOverlay(path_graph),
-    path_graph(path_graph) {
+    VectorizableOverlay::VectorizableOverlay(path_graph),
+    underlying_path_graph(path_graph) {
+    assert(underlying_graph != nullptr);
+    assert(underlying_path_graph != nullptr);
 }
 
 PathVectorizableOverlay::PathVectorizableOverlay() {
@@ -146,82 +149,85 @@ PathVectorizableOverlay::~PathVectorizableOverlay() {
 }
 
 size_t PathVectorizableOverlay::get_path_count() const {
-    return path_graph->get_path_count();
+    return underlying_path_graph->get_path_count();
 }
     
 bool PathVectorizableOverlay::has_path(const std::string& path_name) const {
-    return path_graph->has_path(path_name);
+    return underlying_path_graph->has_path(path_name);
 }
     
 path_handle_t PathVectorizableOverlay::get_path_handle(const std::string& path_name) const {
-    return path_graph->get_path_handle(path_name);
+    return underlying_path_graph->get_path_handle(path_name);
 }
     
 string PathVectorizableOverlay::get_path_name(const path_handle_t& path_handle) const {
-    return path_graph->get_path_name(path_handle);
+    return underlying_path_graph->get_path_name(path_handle);
 }
     
 bool PathVectorizableOverlay::get_is_circular(const path_handle_t& path_handle) const {
-    return path_graph->get_is_circular(path_handle);
+    return underlying_path_graph->get_is_circular(path_handle);
 }
     
 size_t PathVectorizableOverlay::get_step_count(const path_handle_t& path_handle) const {
-    return path_graph->get_step_count(path_handle);
+    return underlying_path_graph->get_step_count(path_handle);
 }
     
 handle_t PathVectorizableOverlay::get_handle_of_step(const step_handle_t& step_handle) const {
-    return path_graph->get_handle_of_step(step_handle);
+    return underlying_path_graph->get_handle_of_step(step_handle);
 }
     
 step_handle_t PathVectorizableOverlay::path_begin(const path_handle_t& path_handle) const {
-    return path_graph->path_begin(path_handle);
+    return underlying_path_graph->path_begin(path_handle);
 }
     
 step_handle_t PathVectorizableOverlay::path_end(const path_handle_t& path_handle) const {
-    return path_graph->path_end(path_handle);
+    return underlying_path_graph->path_end(path_handle);
 }
     
 step_handle_t PathVectorizableOverlay::path_back(const path_handle_t& path_handle) const {
-    return path_graph->path_back(path_handle);
+    return underlying_path_graph->path_back(path_handle);
 }
     
 step_handle_t PathVectorizableOverlay::path_front_end(const path_handle_t& path_handle) const {
-    return path_graph->path_front_end(path_handle);
+    return underlying_path_graph->path_front_end(path_handle);
 }
     
 bool PathVectorizableOverlay::has_next_step(const step_handle_t& step_handle) const {
-    return path_graph->has_next_step(step_handle);
+    return underlying_path_graph->has_next_step(step_handle);
 }
     
 bool PathVectorizableOverlay::has_previous_step(const step_handle_t& step_handle) const {
-    return path_graph->has_previous_step(step_handle);
+    return underlying_path_graph->has_previous_step(step_handle);
 }
     
 step_handle_t PathVectorizableOverlay::get_next_step(const step_handle_t& step_handle) const {
-    return path_graph->get_next_step(step_handle);
+    return underlying_path_graph->get_next_step(step_handle);
 }
     
 step_handle_t PathVectorizableOverlay::get_previous_step(const step_handle_t& step_handle) const {
-    return path_graph->get_previous_step(step_handle);
+    return underlying_path_graph->get_previous_step(step_handle);
 }
     
 path_handle_t PathVectorizableOverlay::get_path_handle_of_step(const step_handle_t& step_handle) const {
-    return path_graph->get_path_handle_of_step(step_handle);
+    return underlying_path_graph->get_path_handle_of_step(step_handle);
 }
     
 bool PathVectorizableOverlay::for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const {
-    return path_graph->for_each_path_handle(iteratee);
+    return underlying_path_graph->for_each_path_handle(iteratee);
 }
     
 bool PathVectorizableOverlay::for_each_step_on_handle_impl(const handle_t& handle,
                                                            const function<bool(const step_handle_t&)>& iteratee) const {
-    return path_graph->for_each_step_on_handle(handle, iteratee);
+    return underlying_path_graph->for_each_step_on_handle(handle, iteratee);
 }
     
 
 PathPositionVectorizableOverlay::PathPositionVectorizableOverlay(const PathPositionHandleGraph* path_position_graph) :
-    PathVectorizableOverlay(path_position_graph),
-    path_position_graph(path_position_graph) {
+    PathVectorizableOverlay::PathVectorizableOverlay(path_position_graph),
+    underlying_path_position_graph(path_position_graph) {
+    assert(underlying_graph != nullptr);
+    assert(underlying_path_graph != nullptr);
+    assert(underlying_path_position_graph != nullptr);
 }
 
 PathPositionVectorizableOverlay::PathPositionVectorizableOverlay() {
@@ -233,16 +239,16 @@ PathPositionVectorizableOverlay::~PathPositionVectorizableOverlay() {
 }
 
 size_t PathPositionVectorizableOverlay::get_path_length(const path_handle_t& path_handle) const {
-    return path_position_graph->get_path_length(path_handle);
+    return underlying_path_position_graph->get_path_length(path_handle);
 }
 
 size_t PathPositionVectorizableOverlay::get_position_of_step(const step_handle_t& step) const {
-    return path_position_graph->get_position_of_step(step);
+    return underlying_path_position_graph->get_position_of_step(step);
 }
     
 step_handle_t PathPositionVectorizableOverlay::get_step_at_position(const path_handle_t& path,
                                                                     const size_t& position) const {
-    return path_position_graph->get_step_at_position(path, position);
+    return underlying_path_position_graph->get_step_at_position(path, position);
 }
 
 


### PR DESCRIPTION
This is a quick and dirty overlay to make any graph vectorizable (ie packable).  

While testing this, I discovered that xg's implementation of the interface is inconsistent in that `node_vector_offset()` returns a 0-based offset, but `node_at_vector_offest()` expects a 1-based offset.  This should probably get fixed up, but will wait for xg to stabilize first. 

