### PR TITLE
Memory efficient path position overlay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ INSTALL_PREFIX?=/usr/local
 INSTALL_LIB_DIR=$(INSTALL_PREFIX)/lib
 INSTALL_INC_DIR=$(INSTALL_PREFIX)/include
 
-OBJS:=$(OBJ_DIR)/eades_algorithm.o $(OBJ_DIR)/hash_graph.o $(OBJ_DIR)/is_single_stranded.o $(OBJ_DIR)/node.o $(OBJ_DIR)/odgi.o $(OBJ_DIR)/packed_graph.o $(OBJ_DIR)/packed_structs.o $(OBJ_DIR)/path_position_overlays.o $(OBJ_DIR)/vectorizable_overlays.o $(OBJ_DIR)/split_strand_graph.o $(OBJ_DIR)/utility.o
+OBJS:=$(OBJ_DIR)/eades_algorithm.o $(OBJ_DIR)/hash_graph.o $(OBJ_DIR)/is_single_stranded.o $(OBJ_DIR)/node.o $(OBJ_DIR)/odgi.o $(OBJ_DIR)/packed_graph.o $(OBJ_DIR)/packed_structs.o $(OBJ_DIR)/path_position_overlays.o $(OBJ_DIR)/packed_path_position_overlays.o $(OBJ_DIR)/vectorizable_overlays.o $(OBJ_DIR)/split_strand_graph.o $(OBJ_DIR)/utility.o
 
 CXXFLAGS :=-O3 -Werror=return-type -std=c++14 -ggdb -g -msse4.2 -I$(INC_DIR) $(CXXFLAGS)
 
@@ -50,6 +50,9 @@ $(OBJ_DIR)/packed_structs.o: $(SRC_DIR)/packed_structs.cpp $(INC_DIR)/bdsg/packe
 
 $(OBJ_DIR)/path_position_overlays.o: $(SRC_DIR)/path_position_overlays.cpp $(INC_DIR)/bdsg/path_position_overlays.hpp
 	$(CXX) $(CXXFLAGS) -c $(SRC_DIR)/path_position_overlays.cpp -o $(OBJ_DIR)/path_position_overlays.o
+
+$(OBJ_DIR)/packed_path_position_overlays.o: $(SRC_DIR)/packed_path_position_overlays.cpp $(INC_DIR)/bdsg/packed_path_position_overlays.hpp
+	$(CXX) $(CXXFLAGS) -c $(SRC_DIR)/packed_path_position_overlays.cpp -o $(OBJ_DIR)/packed_path_position_overlays.o
 
 $(OBJ_DIR)/vectorizable_overlays.o: $(SRC_DIR)/vectorizable_overlays.cpp $(INC_DIR)/bdsg/vectorizable_overlays.hpp
 	$(CXX) $(CXXFLAGS) -c $(SRC_DIR)/vectorizable_overlays.cpp -o $(OBJ_DIR)/vectorizable_overlays.o

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The easiest way to build `libbdsg` is to use the [easy install repository](https
 - [`sdsl`](https://github.com/simongog/sdsl-lite)
 - [`sparsepp`](https://github.com/greg7mdp/sparsepp)
 - [`DYNAMIC`](https://github.com/xxsds/DYNAMIC)
+- [`BBHash/alltypes`](https://github.com/rizkg/BBHash/tree/alltypes) 
 
 The build process assumes that these libraries and their headers have been installed in a place on the system where the compiler can find them (e.g. in `CPLUS_INCLUDE_PATH`).
 

--- a/include/bdsg/packed_path_position_overlays.hpp
+++ b/include/bdsg/packed_path_position_overlays.hpp
@@ -12,8 +12,10 @@
 #include <handlegraph/mutable_path_deletable_handle_graph.hpp>
 #include <handlegraph/path_position_handle_graph.hpp>
 #include <handlegraph/expanding_overlay_graph.hpp>
+#include <handlegraph/util.hpp>
 #include <BooPHF.h>
 
+#include "bdsg/hash_map.hpp"
 #include "bdsg/packed_structs.hpp"
 
 namespace bdsg {
@@ -218,6 +220,12 @@ public:
     
 protected:
     
+    
+    // local BBHash style hash function for step handles
+    struct StepHash {
+        uint64_t operator()(const step_handle_t& step, uint64_t seed = 0xAAAAAAAA55555555ULL) const;
+    };
+    
     /// Construct the index over path positions
     void index_path_positions();
     
@@ -238,7 +246,7 @@ protected:
     PagedVector positions;
     
     /// A perfect minimal hash function for the step handles
-    boomphf::mphf<step_handle_t, boomphf::SingleHashFunctor<step_handle_t>>* hasher = nullptr;
+    boomphf::mphf<step_handle_t, StepHash>* step_hash = nullptr;
     
     /// The position of the step that hashes to a given index
     PackedVector step_positions;
@@ -277,10 +285,10 @@ public:
     };
     
     /// C++ style range begin over steps
-    iterator begin();
+    iterator begin() const;
     
     /// C++ style range end over steps
-    iterator end();
+    iterator end() const;
     
 private:
     /// The graph whose steps this iterates over

--- a/include/bdsg/packed_path_position_overlays.hpp
+++ b/include/bdsg/packed_path_position_overlays.hpp
@@ -1,0 +1,296 @@
+//
+//  packed_path_position_overlays.hpp
+//  
+//  Contains a memory efficient, generic overlays for PathHandleGraph's that add
+//  the PathPositionHandleGraph interface methods for querying steps by base-pair
+//  position.
+//
+
+#ifndef BDSG_PACKED_PATH_POSITION_OVERLAYS_HPP_INCLUDED
+#define BDSG_PACKED_PATH_POSITION_OVERLAYS_HPP_INCLUDED
+
+#include <handlegraph/mutable_path_deletable_handle_graph.hpp>
+#include <handlegraph/path_position_handle_graph.hpp>
+#include <handlegraph/expanding_overlay_graph.hpp>
+#include <BooPHF.h>
+
+#include "bdsg/packed_structs.hpp"
+
+namespace bdsg {
+    
+using namespace std;
+using namespace handlegraph;
+
+/*
+ * An overlay that adds the PathPositionHandleGraph interface to a PathHandleGraph
+ * by augmenting it with relatively simple data structures.
+ *
+ * To also provide mutable methods, see MutablePositionOverlay below.
+ */
+class PackedPositionOverlay : public PathPositionHandleGraph, public ExpandingOverlayGraph {
+        
+public:
+    
+    PackedPositionOverlay(const PathHandleGraph* graph);
+    PackedPositionOverlay();
+    ~PackedPositionOverlay();
+
+    ////////////////////////////////////////////////////////////////////////////
+    // HandleGraph interface
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Method to check if a node exists by ID
+    bool has_node(nid_t node_id) const;
+    
+    /// Look up the handle for the node with the given ID in the given orientation
+    handle_t get_handle(const nid_t& node_id, bool is_reverse = false) const;
+    
+    /// Get the ID from a handle
+    nid_t get_id(const handle_t& handle) const;
+    
+    /// Get the orientation of a handle
+    bool get_is_reverse(const handle_t& handle) const;
+    
+    /// Invert the orientation of a handle (potentially without getting its ID)
+    handle_t flip(const handle_t& handle) const;
+    
+    /// Get the length of a node
+    size_t get_length(const handle_t& handle) const;
+    
+    /// Get the sequence of a node, presented in the handle's local forward orientation.
+    string get_sequence(const handle_t& handle) const;
+    
+private:
+    
+    /// Loop over all the handles to next/previous (right/left) nodes. Passes
+    /// them to a callback which returns false to stop iterating and true to
+    /// continue. Returns true if we finished and false if we stopped early.
+    bool follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const;
+    
+    /// Loop over all the nodes in the graph in their local forward
+    /// orientations, in their internal stored order. Stop if the iteratee
+    /// returns false. Can be told to run in parallel, in which case stopping
+    /// after a false return value is on a best-effort basis and iteration
+    /// order is not defined.
+    bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
+    
+public:
+    
+    /// Get the number of edges on the right (go_left = false) or left (go_left
+    /// = true) side of the given handle. The default implementation is O(n) in
+    /// the number of edges returned, but graph implementations that track this
+    /// information more efficiently can override this method.
+    size_t get_degree(const handle_t& handle, bool go_left) const;
+    
+    /// Returns true if there is an edge that allows traversal from the left
+    /// handle to the right handle. By default O(n) in the number of edges
+    /// on left, but can be overridden with more efficient implementations.
+    bool has_edge(const handle_t& left, const handle_t& right) const;
+    
+    /// Returns one base of a handle's sequence, in the orientation of the
+    /// handle.
+    char get_base(const handle_t& handle, size_t index) const;
+    
+    /// Returns a substring of a handle's sequence, in the orientation of the
+    /// handle. If the indicated substring would extend beyond the end of the
+    /// handle's sequence, the return value is truncated to the sequence's end.
+    std::string get_subsequence(const handle_t& handle, size_t index, size_t size) const;
+    
+    /// Return the number of nodes in the graph
+    size_t get_node_count(void) const;
+    
+    /// Return the smallest ID in the graph, or some smaller number if the
+    /// smallest ID is unavailable. Return value is unspecified if the graph is empty.
+    nid_t min_node_id(void) const;
+    
+    /// Return the largest ID in the graph, or some larger number if the
+    /// largest ID is unavailable. Return value is unspecified if the graph is empty.
+    nid_t max_node_id(void) const;
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Path handle interface
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Returns the number of paths stored in the graph
+    size_t get_path_count() const;
+
+    /// Determine if a path name exists and is legal to get a path handle for.
+    bool has_path(const std::string& path_name) const;
+
+    /// Look up the path handle for the given path name.
+    /// The path with that name must exist.
+    path_handle_t get_path_handle(const std::string& path_name) const;
+
+    /// Look up the name of a path from a handle to it
+    string get_path_name(const path_handle_t& path_handle) const;
+    
+    /// Look up whether a path is circular
+    bool get_is_circular(const path_handle_t& path_handle) const;
+
+    /// Returns the number of node steps in the path
+    size_t get_step_count(const path_handle_t& path_handle) const;
+
+    /// Get a node handle (node ID and orientation) from a handle to an step on a path
+    handle_t get_handle_of_step(const step_handle_t& step_handle) const;
+
+    /// Get a handle to the first step, or in a circular path to an arbitrary step
+    /// considered "first". If the path is empty, returns the past-the-last step
+    /// returned by path_end.
+    step_handle_t path_begin(const path_handle_t& path_handle) const;
+    
+    /// Get a handle to a fictitious position past the end of a path. This position is
+    /// return by get_next_step for the final step in a path in a non-circular path.
+    /// Note that get_next_step will *NEVER* return this value for a circular path.
+    step_handle_t path_end(const path_handle_t& path_handle) const;
+    
+    /// Get a handle to the last step, which will be an arbitrary step in a circular path that
+    /// we consider "last" based on our construction of the path. If the path is empty
+    /// then the implementation must return the same value as path_front_end().
+    step_handle_t path_back(const path_handle_t& path_handle) const;
+    
+    /// Get a handle to a fictitious position before the beginning of a path. This position is
+    /// return by get_previous_step for the first step in a path in a non-circular path.
+    /// Note: get_previous_step will *NEVER* return this value for a circular path.
+    step_handle_t path_front_end(const path_handle_t& path_handle) const;
+    
+    /// Returns true if the step is not the last step in a non-circular path.
+    bool has_next_step(const step_handle_t& step_handle) const;
+    
+    /// Returns true if the step is not the first step in a non-circular path.
+    bool has_previous_step(const step_handle_t& step_handle) const;
+    
+    /// Returns a handle to the next step on the path. If the given step is the final step
+    /// of a non-circular path, returns the past-the-last step that is also returned by
+    /// path_end. In a circular path, the "last" step will loop around to the "first" (i.e.
+    /// the one returned by path_begin).
+    /// Note: to iterate over each step one time, even in a circular path, consider
+    /// for_each_step_in_path.
+    step_handle_t get_next_step(const step_handle_t& step_handle) const;
+    
+    /// Returns a handle to the previous step on the path. If the given step is the first
+    /// step of a non-circular path, this method has undefined behavior. In a circular path,
+    /// it will loop around from the "first" step (i.e. the one returned by path_begin) to
+    /// the "last" step.
+    /// Note: to iterate over each step one time, even in a circular path, consider
+    /// for_each_step_in_path.
+    step_handle_t get_previous_step(const step_handle_t& step_handle) const;
+    
+    /// Returns a handle to the path that an step is on
+    path_handle_t get_path_handle_of_step(const step_handle_t& step_handle) const;
+    
+private:
+    /// Execute a function on each path in the graph
+    bool for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const;
+    
+    /// Calls the given function for each step of the given handle on a path.
+    bool for_each_step_on_handle_impl(const handle_t& handle,
+                                      const function<bool(const step_handle_t&)>& iteratee) const;
+    
+public:
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Path position interface
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Returns the length of a path measured in bases of sequence.
+    size_t get_path_length(const path_handle_t& path_handle) const;
+    
+    /// Returns the position along the path of the beginning of this step measured in
+    /// bases of sequence. In a circular path, positions start at the step returned by
+    /// path_begin().
+    size_t get_position_of_step(const step_handle_t& step) const;
+    
+    /// Returns the step at this position, measured in bases of sequence starting at
+    /// the step returned by path_begin(). If the position is past the end of the
+    /// path, returns path_end().
+    step_handle_t get_step_at_position(const path_handle_t& path,
+                                       const size_t& position) const;
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Expanding overlay interface
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /**
+     * Returns the handle in the underlying graph that corresponds to a handle in the
+     * overlay
+     */
+    handle_t get_underlying_handle(const handle_t& handle) const;
+    
+protected:
+    
+    /// Construct the index over path positions
+    void index_path_positions();
+    
+    /// The graph we're overlaying
+    const PathHandleGraph* graph = nullptr;
+    
+    /// Map from path_handle to the range of indexes that contain its records
+    /// in the steps and positions vectors
+    hash_map<int64_t, pair<size_t, size_t>> path_range;
+    
+    /// The first half of the steps
+    PagedVector steps_0;
+    
+    /// The second half of the steps
+    PagedVector steps_1;
+    
+    /// The positions of the steps
+    PagedVector positions;
+    
+    /// A perfect minimal hash function for the step handles
+    boomphf::mphf<step_handle_t, boomphf::SingleHashFunctor<step_handle_t>>* hasher = nullptr;
+    
+    /// The position of the step that hashes to a given index
+    PackedVector step_positions;
+};
+
+/*
+ * A wrapper for constructing the perfect minimal hash function that sequentially
+ * returns all steps of a PathHandleGraph from an iterator struct
+ */
+struct BBHashHelper {
+public:
+    BBHashHelper(const PathHandleGraph* graph);
+    BBHashHelper() = delete;
+    ~BBHashHelper() = default;
+    
+    struct iterator {
+    public:
+        iterator(const iterator& other) = default;
+        iterator() = delete;
+        ~iterator() = default;
+        iterator& operator=(const iterator& other) = default;
+        iterator& operator++();
+        step_handle_t operator*() const;
+        bool operator==(const iterator& other) const;
+        bool operator!=(const iterator& other) const;
+        
+    private:
+        
+        iterator(const BBHashHelper& iteratee, size_t path_handle_idx);
+        
+        size_t path_handle_idx = 0;
+        step_handle_t step;
+        const BBHashHelper& iteratee;
+        
+        friend class BBHashHelper;
+    };
+    
+    /// C++ style range begin over steps
+    iterator begin();
+    
+    /// C++ style range end over steps
+    iterator end();
+    
+private:
+    /// The graph whose steps this iterates over
+    const PathHandleGraph* graph;
+    /// An ordering of the path handles so we can refer to them by index
+    vector<path_handle_t> path_handles;
+    
+    friend class iterator;
+};
+    
+}
+
+#endif

--- a/src/packed_path_position_overlays.cpp
+++ b/src/packed_path_position_overlays.cpp
@@ -214,7 +214,7 @@ namespace bdsg {
         for_each_path_handle([&](const path_handle_t& path_handle) {
             cumul_path_size += get_step_count(path_handle);
         });
-        
+                
         // resize the vectors to the number of step handles
         steps_0.resize(cumul_path_size);
         steps_1.resize(cumul_path_size);
@@ -222,7 +222,7 @@ namespace bdsg {
         step_positions.resize(cumul_path_size);
         
         // make a perfect minimal hash over the step handles
-        step_hash = new boomphf::mphf<step_handle_t, StepHash>(cumul_path_size, BBHashHelper(graph), 1, 1.0);
+        step_hash = new boomphf::mphf<step_handle_t, StepHash>(cumul_path_size, BBHashHelper(graph), 1, 1.0, false, false);
         
         size_t i = 0;
         for_each_path_handle([&](const path_handle_t& path_handle) {
@@ -281,7 +281,9 @@ namespace bdsg {
             step == iteratee.graph->path_end(iteratee.path_handles[path_handle_idx])) {
             // we either went off the end or looped around a circular path to the beginning again
             ++path_handle_idx;
-            step = iteratee.graph->path_begin(iteratee.path_handles[path_handle_idx]);
+            if (path_handle_idx < iteratee.path_handles.size()) {
+                step = iteratee.graph->path_begin(iteratee.path_handles[path_handle_idx]);
+            }
         }
         return *this;
     }

--- a/src/packed_path_position_overlays.cpp
+++ b/src/packed_path_position_overlays.cpp
@@ -1,0 +1,300 @@
+#include "bdsg/packed_path_position_overlays.hpp"
+
+
+namespace bdsg {
+
+    PackedPositionOverlay::PackedPositionOverlay(const PathHandleGraph* graph) : graph(graph), steps_0(1024), steps_1(256), positions(256) {
+        index_path_positions();
+    }
+
+    PackedPositionOverlay::PackedPositionOverlay() {
+        
+    }
+    
+    PackedPositionOverlay::~PackedPositionOverlay() {
+        delete step_hash;
+    }
+    
+    bool PackedPositionOverlay::has_node(nid_t node_id) const {
+        return graph->has_node(node_id);
+    }
+    
+    handle_t PackedPositionOverlay::get_handle(const nid_t& node_id, bool is_reverse) const {
+        return graph->get_handle(node_id, is_reverse);
+    }
+    
+    nid_t PackedPositionOverlay::get_id(const handle_t& handle) const {
+        return graph->get_id(handle);
+    }
+    
+    bool PackedPositionOverlay::get_is_reverse(const handle_t& handle) const {
+        return graph->get_is_reverse(handle);
+    }
+    
+    handle_t PackedPositionOverlay::flip(const handle_t& handle) const {
+        return graph->flip(handle);
+    }
+    
+    size_t PackedPositionOverlay::get_length(const handle_t& handle) const {
+        return graph->get_length(handle);
+    }
+    
+    string PackedPositionOverlay::get_sequence(const handle_t& handle) const {
+        return graph->get_sequence(handle);
+    }
+    
+    bool PackedPositionOverlay::follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const {
+        return graph->follow_edges(handle, go_left, iteratee);
+    }
+    
+    bool PackedPositionOverlay::for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel) const {
+        return graph->for_each_handle(iteratee, parallel);
+    }
+    
+    size_t PackedPositionOverlay::get_degree(const handle_t& handle, bool go_left) const {
+        return graph->get_degree(handle, go_left);
+    }
+    
+    bool PackedPositionOverlay::has_edge(const handle_t& left, const handle_t& right) const {
+        return graph->has_edge(left, right);
+    }
+    
+    char PackedPositionOverlay::get_base(const handle_t& handle, size_t index) const {
+        return graph->get_base(handle, index);
+    }
+    
+    std::string PackedPositionOverlay::get_subsequence(const handle_t& handle, size_t index, size_t size) const {
+        return graph->get_subsequence(handle, index, size);
+    }
+    
+    size_t PackedPositionOverlay::get_node_count(void) const {
+        return graph->get_node_count();
+    }
+    
+    nid_t PackedPositionOverlay::min_node_id(void) const {
+        return graph->min_node_id();
+    }
+    
+    nid_t PackedPositionOverlay::max_node_id(void) const {
+        return graph->max_node_id();
+    }
+    
+    size_t PackedPositionOverlay::get_path_count() const {
+        return graph->get_path_count();
+    }
+    
+    bool PackedPositionOverlay::has_path(const std::string& path_name) const {
+        return graph->has_path(path_name);
+    }
+    
+    path_handle_t PackedPositionOverlay::get_path_handle(const std::string& path_name) const {
+        return graph->get_path_handle(path_name);
+    }
+    
+    string PackedPositionOverlay::get_path_name(const path_handle_t& path_handle) const {
+        return graph->get_path_name(path_handle);
+    }
+    
+    bool PackedPositionOverlay::get_is_circular(const path_handle_t& path_handle) const {
+        return graph->get_is_circular(path_handle);
+    }
+    
+    size_t PackedPositionOverlay::get_step_count(const path_handle_t& path_handle) const {
+        return graph->get_step_count(path_handle);
+    }
+    
+    handle_t PackedPositionOverlay::get_handle_of_step(const step_handle_t& step_handle) const {
+        return graph->get_handle_of_step(step_handle);
+    }
+    
+    step_handle_t PackedPositionOverlay::path_begin(const path_handle_t& path_handle) const {
+        return graph->path_begin(path_handle);
+    }
+    
+    step_handle_t PackedPositionOverlay::path_end(const path_handle_t& path_handle) const {
+        return graph->path_end(path_handle);
+    }
+    
+    step_handle_t PackedPositionOverlay::path_back(const path_handle_t& path_handle) const {
+        return graph->path_back(path_handle);
+    }
+    
+    step_handle_t PackedPositionOverlay::path_front_end(const path_handle_t& path_handle) const {
+        return graph->path_front_end(path_handle);
+    }
+    
+    bool PackedPositionOverlay::has_next_step(const step_handle_t& step_handle) const {
+        return graph->has_next_step(step_handle);
+    }
+    
+    bool PackedPositionOverlay::has_previous_step(const step_handle_t& step_handle) const {
+        return graph->has_previous_step(step_handle);
+    }
+    
+    step_handle_t PackedPositionOverlay::get_next_step(const step_handle_t& step_handle) const {
+        return graph->get_next_step(step_handle);
+    }
+    
+    step_handle_t PackedPositionOverlay::get_previous_step(const step_handle_t& step_handle) const {
+        return graph->get_previous_step(step_handle);
+    }
+    
+    path_handle_t PackedPositionOverlay::get_path_handle_of_step(const step_handle_t& step_handle) const {
+        return graph->get_path_handle_of_step(step_handle);
+    }
+    
+    bool PackedPositionOverlay::for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const {
+        return graph->for_each_path_handle(iteratee);
+    }
+    
+    bool PackedPositionOverlay::for_each_step_on_handle_impl(const handle_t& handle,
+                                                       const function<bool(const step_handle_t&)>& iteratee) const {
+        return graph->for_each_step_on_handle(handle, iteratee);
+    }
+    
+    size_t PackedPositionOverlay::get_path_length(const path_handle_t& path_handle) const {
+        const auto& range = path_range.at(as_integer(path_handle));
+        if (range.first == range.second) {
+            return 0;
+        }
+        step_handle_t step;
+        as_integers(step)[0] = steps_0.get(range.second - 1);
+        as_integers(step)[1] = steps_1.get(range.second - 1);
+        return positions.get(range.second - 1) + get_length(get_handle_of_step(step));
+    }
+    
+    size_t PackedPositionOverlay::get_position_of_step(const step_handle_t& step) const {
+        if (step == path_end(get_path_handle_of_step(step))) {
+            return get_path_length(get_path_handle_of_step(step));
+        }
+        else {
+            return step_positions.get(step_hash->lookup(step));
+        }
+    }
+    
+    step_handle_t PackedPositionOverlay::get_step_at_position(const path_handle_t& path,
+                                                              const size_t& position) const {
+        
+        const auto& range = path_range.at(as_integer(path_handle));
+        
+        // check if position it outside the range (handles edge case of an empty path too)
+        if (position >= get_path_length(path)) {
+            return path_end(path);
+        }
+        
+        // bisect search within the range to find the index with the steps
+        size_t low = range.first;
+        size_t hi = range.second;
+        while (hi > low + 1) {
+            size_t mid = (hi + low) / 2;
+            if (position < positions.get(mid)) {
+                hi = mid;
+            }
+            else {
+                low = mid;
+            }
+        }
+        
+        // unpack the integers at the same index into a step
+        step_handle_t step;
+        as_integers(step)[0] = steps_0.get(low);
+        as_integers(step)[1] = steps_1.get(low);
+        return step;
+    }
+    
+    handle_t PackedPositionOverlay::get_underlying_handle(const handle_t& handle) const {
+        return handle;
+    }
+    
+    void PackedPositionOverlay::index_path_positions() {
+        
+        size_t cumul_path_size = 0;
+        
+        for_each_path_handle([&](const path_handle_t& path_handle) {
+            cumul_path_size += get_step_count(path_handle);
+        });
+        
+        // resize the vectors to the number of step handles
+        steps_0.resize(cumul_path_size);
+        steps_1.resize(cumul_path_size);
+        positions.resize(cumul_path_size);
+        step_positions.resize(cumul_path_size);
+        
+        // make a perfect minimal hash over the step handles
+        step_hash = new boomphf::mphf<step_handle_t, boomphf::SingleHashFunctor<step_handle_t>>(cumul_path_size,
+                                                                                             BBHashHelper(graph),
+                                                                                             1, 1.0);
+        
+        size_t i = 0;
+        for_each_path_handle([&](const path_handle_t& path_handle) {
+            // get
+            auto& range = path_range[as_integer(path_handle)];
+            range.first = i;
+            size_t position = 0;
+            for_each_step_in_path(path_handle, [&](const step_handle_t& step) {
+                
+                // fill in the position to step index
+                steps_0.set(i, as_integers(step)[0]);
+                steps_1.set(i, as_integers(step)[1]);
+                positions.set(i, position);
+                
+                // fill in the step to position index
+                step_positions.set(step_hash->lookup(step), position);
+                
+                position += get_length(get_handle_of_step(step));
+                ++i;
+            });
+            range.second = i;
+        });
+    }
+    
+    BBHashHelper::BBHashHelper(const PathHandleGraph* graph) : graph(graph) {
+        path_handles.reserve(graph->get_path_count());
+        graph->for_each_path_handle([&](const path_handle_t& path_handle)) {
+            if (!graph->is_empty(path_handle)) {
+                // this path contains steps, we want to iterate over it
+                path_handles.push_back(path_handle);
+            }
+        }
+    }
+    
+    BBHashHelper::iterator BBHashHelper::begin() {
+        return iterator(*this, 0);
+    }
+    
+    BBHashHelper::iterator BBHashHelper::end() {
+        return iterator(*this, path_handles.size());
+    }
+    
+    BBHashHelper::iterator::iterator(const BBHashHelper& iteratee, size_t path_handle_idx) : iteratee(iteratee), path_handle_idx(path_handle_idx) {
+        if (path_handle_idx < iteratee.path_handles.size()) {
+            step = iteratee.graph->path_begin(iteratee.path_handles[path_handle_idx]);
+        }
+    }
+    
+    BBHashHelper::iterator& BBHashHelper::iterator::operator++() {
+        step = iteratee.graph->get_next_step(step);
+        if (step == iteratee.graph->path_begin(iteratee.path_handles[path_handle_idx]) ||
+            step == iteratee.graph->path_end(iteratee.path_handles[path_handle_idx])) {
+            // we either went off the end or looped around a circular path to the beginning again
+            ++path_handle_idx;
+            step = iteratee.graph->path_begin(iteratee.path_handles[path_handle_idx]);
+        }
+    }
+    
+    step_handle_t BBHashHelper::iterator::operator*() const {
+        return step;
+    }
+    
+    bool BBHashHelper::iterator::operator==(const BBHashHelper::iterator& other) const {
+        // on the end iterator, we don't care what the step is, only that we're past-the-last
+        // path handle
+        return (&iteratee == &other.iteratee
+                && path_handle_idx == other.path_handle_idx
+                && (step == other.step || path_handle_idx == iteratee.path_handles.size()));
+    }
+    
+    bool BBHashHelper::iterator::operator!=(const BBHashHelper::iterator& other) const {
+        return !(*this == other);
+    }
+}

--- a/src/test_libbdsg.cpp
+++ b/src/test_libbdsg.cpp
@@ -18,6 +18,7 @@
 #include "bdsg/hash_graph.hpp"
 #include "bdsg/packed_structs.hpp"
 #include "bdsg/path_position_overlays.hpp"
+#include "bdsg/packed_path_position_overlays.hpp"
 #include "bdsg/vectorizable_overlays.hpp"
 
 using namespace bdsg;
@@ -2408,27 +2409,38 @@ void test_path_position_overlays() {
         step_handle_t s2 = graph.append_step(p1, h2);
         step_handle_t s3 = graph.append_step(p1, h4);
         
-        // static position overlay
+        // static position overlays
         {
-            PositionOverlay overlay(&graph);
+            vector<PathPositionHandleGraph*> overlays;
             
-            assert(overlay.get_path_length(p1) == 9);
+            PositionOverlay basic_overlay(&graph);
+            PackedPositionOverlay packed_overlay(&graph);
             
-            assert(overlay.get_position_of_step(s1) == 0);
-            assert(overlay.get_position_of_step(s2) == 3);
-            assert(overlay.get_position_of_step(s3) == 4);
+            overlays.push_back(&basic_overlay);
+            overlays.push_back(&packed_overlay);
             
-            assert(overlay.get_step_at_position(p1, 0) == s1);
-            assert(overlay.get_step_at_position(p1, 1) == s1);
-            assert(overlay.get_step_at_position(p1, 2) == s1);
-            assert(overlay.get_step_at_position(p1, 3) == s2);
-            assert(overlay.get_step_at_position(p1, 4) == s3);
-            assert(overlay.get_step_at_position(p1, 5) == s3);
-            assert(overlay.get_step_at_position(p1, 6) == s3);
-            assert(overlay.get_step_at_position(p1, 7) == s3);
-            assert(overlay.get_step_at_position(p1, 8) == s3);
-            assert(overlay.get_step_at_position(p1, 9) == overlay.path_end(p1));
+            for (PathPositionHandleGraph* implementation : overlays) {
+                PathPositionHandleGraph& overlay = *implementation;
+                
+                assert(overlay.get_path_length(p1) == 9);
+                
+                assert(overlay.get_position_of_step(s1) == 0);
+                assert(overlay.get_position_of_step(s2) == 3);
+                assert(overlay.get_position_of_step(s3) == 4);
+                
+                assert(overlay.get_step_at_position(p1, 0) == s1);
+                assert(overlay.get_step_at_position(p1, 1) == s1);
+                assert(overlay.get_step_at_position(p1, 2) == s1);
+                assert(overlay.get_step_at_position(p1, 3) == s2);
+                assert(overlay.get_step_at_position(p1, 4) == s3);
+                assert(overlay.get_step_at_position(p1, 5) == s3);
+                assert(overlay.get_step_at_position(p1, 6) == s3);
+                assert(overlay.get_step_at_position(p1, 7) == s3);
+                assert(overlay.get_step_at_position(p1, 8) == s3);
+                assert(overlay.get_step_at_position(p1, 9) == overlay.path_end(p1));
+            }
         }
+        
         
         // mutable position overlay
         {
@@ -2517,6 +2529,7 @@ void test_path_position_overlays() {
             assert(overlay.get_step_at_position(p1, 17) == overlay.path_end(p1));
         }
     }
+    cerr << "PathPositionOverlay tests successful!" << endl;
 }
 
 void test_vectorizable_overlays() {
@@ -2530,7 +2543,6 @@ void test_vectorizable_overlays() {
     //implementations.push_back(&og);
     
     for (MutablePathDeletableHandleGraph* implementation : implementations) {
-        cerr << endl << "*******************" << endl;
         
         MutablePathDeletableHandleGraph& graph = *implementation;
         
@@ -2586,6 +2598,7 @@ void test_vectorizable_overlays() {
                 }
             });
     }
+    cerr << "VectorizableOverlay tests successful!" << endl;
 }
 
 


### PR DESCRIPTION
@glennhickey 

Adds a memory-efficient, static overlay that adds the `PathPositionHandleGraph` interface over a generic `PathHandleGraph`. 

Also adds a new external dependency: `BBHash`. They have a somewhat odd software design where the master branch provides hashing for (as far as I can tell) only integer types. If you want to hash non-integer types you have to use a separate branch `alltypes` in the same repository, so the dependency is actually on that branch.