### PR TITLE
Make vectorizable overlay smaller

### DIFF
--- a/include/bdsg/utility.hpp
+++ b/include/bdsg/utility.hpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <iomanip>
 #include <functional>
+#include <omp.h>
 
 namespace bdsg {
 
@@ -55,7 +56,19 @@ inline char int_as_dna(int i) {
     
 // Convert a quantity in bytes to a human-friendly string
 string format_memory(size_t s);
-    
+
+/// Return the number of threads that OMP will produce for a parallel section.
+/// TODO: Assumes that this is the same for every parallel section.
+inline int get_thread_count(void) {
+    int thread_count = 1;
+#pragma omp parallel
+    {
+#pragma omp master
+        thread_count = omp_get_num_threads();
+    }
+    return thread_count;
+}
+
 }
 
 #endif

--- a/src/packed_path_position_overlays.cpp
+++ b/src/packed_path_position_overlays.cpp
@@ -1,5 +1,5 @@
 #include "bdsg/packed_path_position_overlays.hpp"
-
+#include "bdsg/utility.hpp"
 
 namespace bdsg {
 
@@ -222,7 +222,7 @@ namespace bdsg {
         step_positions.resize(cumul_path_size);
         
         // make a perfect minimal hash over the step handles
-        step_hash = new boomphf::mphf<step_handle_t, StepHash>(cumul_path_size, BBHashHelper(graph), 1, 1.0, false, false);
+        step_hash = new boomphf::mphf<step_handle_t, StepHash>(cumul_path_size, BBHashHelper(graph), get_thread_count(), 1.0, false, false);
         
         size_t i = 0;
         for_each_path_handle([&](const path_handle_t& path_handle) {


### PR DESCRIPTION
Win inspiration from #25, use bbhash instead of normal hash tables for keeping track of node and edge ranks in the vectorizable overlay.  

I'm using parallel construction for the bbhash, and took the liberty of activating this for the PackedPositionOverlay.  @jeizenga is this okay?  libbdsg's already dependent on omp, and I think we'll generally be building overlays at the top level where we have access to all the threads. 

