### PR TITLE
Implement ID increment for HashGraph

### DIFF
--- a/include/bdsg/hash_graph.hpp
+++ b/include/bdsg/hash_graph.hpp
@@ -410,7 +410,7 @@ private:
     nid_t get_internal_id(const handle_t& handle) const;
     
     /// Convert a handle from an internal handle to a real ID space, serializable handle.
-    handle_t apply_id_offset(const handle_t& internal) const;
+    static handle_t apply_id_offset(const handle_t& internal, nid_t id_offset) const;
 };
     
     

--- a/include/bdsg/hash_graph.hpp
+++ b/include/bdsg/hash_graph.hpp
@@ -327,8 +327,9 @@ private:
         /// The occurrences of this node on paths;
         vector<path_mapping_t*> occurrences;
         
-        /// Write the node to an out stream
-        void serialize(ostream& out) const;
+        /// Write the node to an out stream, applying the given ID offset to
+        /// nodes referenced by edges.
+        void serialize(ostream& out, nid_t id_offset = 0) const;
         /// Read the node (in the format written by serialize()) from an in stream.
         void deserialize(istream& in);
     };

--- a/include/bdsg/hash_graph.hpp
+++ b/include/bdsg/hash_graph.hpp
@@ -327,7 +327,7 @@ private:
         /// The occurrences of this node on paths;
         vector<path_mapping_t*> occurrences;
         
-        /// Write the node to an out stream.
+        /// Write the node to an out stream
         void serialize(ostream& out) const;
         /// Read the node (in the format written by serialize()) from an in stream.
         void deserialize(istream& in);
@@ -369,8 +369,9 @@ private:
         /// is null, inserts at the end.
         path_mapping_t* insert_before(const handle_t& handle, path_mapping_t* mapping);
         
-        /// Write the path to an out stream.
-        void serialize(ostream& out) const;
+        /// Write the path to an out stream, applying the given offset to all
+        /// node IDs referenced by the path.
+        void serialize(ostream& out, nid_t id_offset = 0) const;
         
         /// Read the path (in the format written by serialize()) from an in stream.
         void deserialize(istream& in);
@@ -388,6 +389,10 @@ private:
     /// The minimum ID in the graph
     nid_t min_id = numeric_limits<nid_t>::max();
     
+    /// The node ID offset accumulated from increment_node_ids. Applied
+    /// dynamically when looking at handles, and permanently on serialization.
+    nid_t id_offset = 0;
+    
     /// Encodes the graph topology
     hash_map<nid_t, node_t> graph;
     
@@ -399,6 +404,10 @@ private:
     
     /// The next path ID we will assign to a new path
     int64_t next_path_id = 1;
+    
+    /// Get ther internal ID of a handle which is its index into internal data structures.
+    /// Does not have id_offset applied.
+    nid_t HashGraph::get_internal_id(const handle_t& handle) const;
 };
     
     

--- a/include/bdsg/hash_graph.hpp
+++ b/include/bdsg/hash_graph.hpp
@@ -407,7 +407,7 @@ private:
     
     /// Get ther internal ID of a handle which is its index into internal data structures.
     /// Does not have id_offset applied.
-    nid_t HashGraph::get_internal_id(const handle_t& handle) const;
+    nid_t get_internal_id(const handle_t& handle) const;
 };
     
     

--- a/include/bdsg/hash_graph.hpp
+++ b/include/bdsg/hash_graph.hpp
@@ -408,6 +408,9 @@ private:
     /// Get ther internal ID of a handle which is its index into internal data structures.
     /// Does not have id_offset applied.
     nid_t get_internal_id(const handle_t& handle) const;
+    
+    /// Convert a handle from an internal handle to a real ID space, serializable handle.
+    handle_t apply_id_offset(const handle_t& internal) const;
 };
     
     

--- a/include/bdsg/hash_graph.hpp
+++ b/include/bdsg/hash_graph.hpp
@@ -410,7 +410,7 @@ private:
     nid_t get_internal_id(const handle_t& handle) const;
     
     /// Convert a handle from an internal handle to a real ID space, serializable handle.
-    static handle_t apply_id_offset(const handle_t& internal, nid_t id_offset) const;
+    static handle_t apply_id_offset(const handle_t& internal, nid_t id_offset);
 };
     
     

--- a/include/bdsg/hash_graph.hpp
+++ b/include/bdsg/hash_graph.hpp
@@ -296,6 +296,11 @@ public:
      * Add the given value to all node IDs
      */
     void increment_node_ids(nid_t increment);
+    
+    /**
+     * Reassign all node IDs as specified by the old->new mapping function.
+     */
+    void reassign_node_ids(const std::function<nid_t(const nid_t&)>& get_new_id);
 
 private:
     
@@ -412,6 +417,9 @@ private:
     
     /// Convert a handle from an internal handle to a real ID space, serializable handle.
     static handle_t apply_id_offset(const handle_t& internal, nid_t id_offset);
+    
+    /// Replace the ID in a handle with a different number
+    static handle_t set_id(const handle_t& internal, nid_t new_id);
 };
     
     

--- a/include/bdsg/odgi.hpp
+++ b/include/bdsg/odgi.hpp
@@ -101,6 +101,9 @@ public:
     /// Add the given value to all node IDs
     void increment_node_ids(nid_t increment);
     
+    /// Reassign all node IDs as specified by the old->new mapping function.
+    void reassign_node_ids(const std::function<nid_t(const nid_t&)>& get_new_id);
+    
     /// Get a handle from a Visit Protobuf object.
     /// Must be using'd to avoid shadowing.
     //handle_t get_handle(const Visit& visit) const;

--- a/include/bdsg/packed_graph.hpp
+++ b/include/bdsg/packed_graph.hpp
@@ -296,6 +296,11 @@ public:
      * Add the given value to all node IDs
      */
     void increment_node_ids(nid_t increment);
+    
+    /**
+     * Reassign all node IDs as specified by the old->new mapping function.
+     */
+    void reassign_node_ids(const std::function<nid_t(const nid_t&)>& get_new_id);
 
 private:
     

--- a/src/hash_graph.cpp
+++ b/src/hash_graph.cpp
@@ -797,7 +797,7 @@ namespace bdsg {
         path_mapping_t* mapping = head;
         bool first_iter = true;
         while (mapping && (first_iter || mapping != head)) { // extra condition for circular paths
-            int64_t step = endianness<int64_t>::to_big_endian(as_integer(apply_id_offset(mapping->handle)));
+            int64_t step = endianness<int64_t>::to_big_endian(as_integer(apply_id_offset(mapping->handle, id_offset)));
 
             out.write((const char*) &step, sizeof(step) / sizeof(char));
             mapping = mapping->next;
@@ -847,14 +847,14 @@ namespace bdsg {
         uint64_t left_edges_size_out = endianness<uint64_t>::to_big_endian(left_edges.size());
         out.write((const char*) &left_edges_size_out, sizeof(left_edges_size_out) / sizeof(char));
         for (size_t i = 0; i < left_edges.size(); i++) {
-        
+            int64_t next_out = endianness<int64_t>::to_big_endian(as_integer(apply_id_offset(left_edges[i], id_offset))); 
             out.write((const char*) &next_out, sizeof(next_out) / sizeof(char));
         }
         
         uint64_t right_edges_size_out = endianness<uint64_t>::to_big_endian(right_edges.size());
         out.write((const char*) &right_edges_size_out, sizeof(right_edges_size_out) / sizeof(char));
         for (size_t i = 0; i < right_edges.size(); i++) {
-            int64_t next_out = endianness<int64_t>::to_big_endian(as_integer(right_edges[i]));
+            int64_t next_out = endianness<int64_t>::to_big_endian(as_integer(apply_id_offset(right_edges[i], id_offset)));
             out.write((const char*) &next_out, sizeof(next_out) / sizeof(char));
         }
         
@@ -980,7 +980,7 @@ namespace bdsg {
         return handlegraph::number_bool_packing::unpack_number(handle);
     }
     
-    handle_t HashGraph::apply_id_offset(const handle_t& internal) const {
+    handle_t HashGraph::apply_id_offset(const handle_t& internal, nid_t id_offset) const {
         nid_t node_id = handlegraph::number_bool_packing::unpack_number(internal);
         bool is_reverse = handlegraph::number_bool_packing::unpack_bit(internal);
         return handlegraph::number_bool_packing::pack(node_id + id_offset, is_reverse);

--- a/src/hash_graph.cpp
+++ b/src/hash_graph.cpp
@@ -980,7 +980,7 @@ namespace bdsg {
         return handlegraph::number_bool_packing::unpack_number(handle);
     }
     
-    handle_t HashGraph::apply_id_offset(const handle_t& internal, nid_t id_offset) const {
+    handle_t HashGraph::apply_id_offset(const handle_t& internal, nid_t id_offset) {
         nid_t node_id = handlegraph::number_bool_packing::unpack_number(internal);
         bool is_reverse = handlegraph::number_bool_packing::unpack_bit(internal);
         return handlegraph::number_bool_packing::pack(node_id + id_offset, is_reverse);

--- a/src/hash_graph.cpp
+++ b/src/hash_graph.cpp
@@ -28,9 +28,9 @@ namespace bdsg {
     }
     
     handle_t HashGraph::create_handle(const string& sequence, const nid_t& id) {
-        graph[id] = node_t(sequence);
-        max_id = max(max_id, id);
-        min_id = min(min_id, id);
+        graph[id - id_offset] = node_t(sequence);
+        max_id = max(max_id, id - id_offset);
+        min_id = min(min_id, id - id_offset);
         return get_handle(id, false);
     }
     
@@ -106,11 +106,11 @@ namespace bdsg {
     }
     
     nid_t HashGraph::min_node_id(void) const {
-        return min_id;
+        return min_id + id_offset;
     }
     
     nid_t HashGraph::max_node_id(void) const {
-        return max_id;
+        return max_id + id_offset;
     }
     
     size_t HashGraph::get_degree(const handle_t& handle, bool go_left) const {

--- a/src/hash_graph.cpp
+++ b/src/hash_graph.cpp
@@ -63,10 +63,6 @@ namespace bdsg {
         return handlegraph::number_bool_packing::pack(node_id - id_offset, is_reverse);
     }
     
-    nid_t HashGraph::get_internal_id(const handle_t& handle) const {
-        return handlegraph::number_bool_packing::unpack_number(handle);
-    }
-    
     nid_t HashGraph::get_id(const handle_t& handle) const {
         return get_internal_id(handle) + id_offset;
     }
@@ -801,13 +797,7 @@ namespace bdsg {
         path_mapping_t* mapping = head;
         bool first_iter = true;
         while (mapping && (first_iter || mapping != head)) { // extra condition for circular paths
-            
-            // Apply the node ID offset to each handle
-            nid_t mapping_node_id = handlegraph::number_bool_packing::unpack_number(mapping->handle);
-            bool mapping_is_reverse = handlegraph::number_bool_packing::unpack_bit(mapping->handle);
-            handle_t offset_handle = handlegraph::number_bool_packing::pack(mapping_node_id + id_offset, mapping_is_reverse);
-            
-            int64_t step = endianness<int64_t>::to_big_endian(as_integer(offset_handle));
+            int64_t step = endianness<int64_t>::to_big_endian(as_integer(apply_id_offset(mapping->handle)));
 
             out.write((const char*) &step, sizeof(step) / sizeof(char));
             mapping = mapping->next;
@@ -857,7 +847,7 @@ namespace bdsg {
         uint64_t left_edges_size_out = endianness<uint64_t>::to_big_endian(left_edges.size());
         out.write((const char*) &left_edges_size_out, sizeof(left_edges_size_out) / sizeof(char));
         for (size_t i = 0; i < left_edges.size(); i++) {
-            int64_t next_out = endianness<int64_t>::to_big_endian(as_integer(left_edges[i]));
+        
             out.write((const char*) &next_out, sizeof(next_out) / sizeof(char));
         }
         
@@ -985,4 +975,15 @@ namespace bdsg {
             }
         }
     }
+    
+    nid_t HashGraph::get_internal_id(const handle_t& handle) const {
+        return handlegraph::number_bool_packing::unpack_number(handle);
+    }
+    
+    handle_t HashGraph::apply_id_offset(const handle_t& internal) const {
+        nid_t node_id = handlegraph::number_bool_packing::unpack_number(internal);
+        bool is_reverse = handlegraph::number_bool_packing::unpack_bit(internal);
+        return handlegraph::number_bool_packing::pack(node_id + id_offset, is_reverse);
+    }
+    
 }

--- a/src/hash_graph.cpp
+++ b/src/hash_graph.cpp
@@ -838,7 +838,7 @@ namespace bdsg {
         }
     }
     
-    void HashGraph::node_t::serialize(ostream& out) const {
+    void HashGraph::node_t::serialize(ostream& out, nid_t id_offset) const {
         
         uint64_t seq_size_out = endianness<uint64_t>::to_big_endian( sequence.size());
         out.write((const char*) &seq_size_out, sizeof(seq_size_out) / sizeof(char));
@@ -911,7 +911,7 @@ namespace bdsg {
         for (const pair<nid_t, node_t>& node_record : graph) {
             nid_t node_id_out = endianness<nid_t>::to_big_endian(node_record.first + id_offset);
             out.write((const char*) &node_id_out, sizeof(node_id_out) / sizeof(char));
-            node_record.second.serialize(out);
+            node_record.second.serialize(out, id_offset);
         }
         
         uint64_t paths_size_out = endianness<uint64_t>::to_big_endian(paths.size());

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -36,6 +36,11 @@ void ODGI::set_id_increment(const nid_t& min_id) {
 void ODGI::increment_node_ids(nid_t increment) {
     throw runtime_error("Not implemented");
 }
+
+/// Reassign all node IDs as specified by the old->new mapping function.
+void ODGI::reassign_node_ids(const std::function<nid_t(const nid_t&)>& get_new_id) {
+    throw runtime_error("Not implemented");
+}
     
 /// Get the orientation of a handle
 bool ODGI::get_is_reverse(const handle_t& handle) const {

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -1844,6 +1844,10 @@ namespace bdsg {
     void PackedGraph::increment_node_ids(nid_t increment) {
         throw runtime_error("Not implemented");
     }
+    
+    void PackedGraph::reassign_node_ids(const std::function<nid_t(const nid_t&)>& get_new_id) {
+        throw runtime_error("Not implemented");
+    }
 
     void PackedGraph::report_memory(ostream& out, bool individual_paths) const {
         size_t grand_total = 0;


### PR DESCRIPTION
I'm doing it as an overlay, basically. We keep an offset between real IDs and internal IDs in the graph hashtable, translate dynamically when converting between handles and IDs, and only actually apply the offset to node IDs and path ID references when we serialize the graph.