### PR TITLE
Remove the run time node ID offsets from HashGraph

### DIFF
--- a/include/bdsg/hash_graph.hpp
+++ b/include/bdsg/hash_graph.hpp
@@ -346,7 +346,7 @@ private:
         
         /// Write the node to an out stream, applying the given ID offset to
         /// nodes referenced by edges.
-        void serialize(ostream& out, nid_t id_offset = 0) const;
+        void serialize(ostream& out) const;
         /// Read the node (in the format written by serialize()) from an in stream.
         void deserialize(istream& in);
     };
@@ -389,7 +389,7 @@ private:
         
         /// Write the path to an out stream, applying the given offset to all
         /// node IDs referenced by the path.
-        void serialize(ostream& out, nid_t id_offset = 0) const;
+        void serialize(ostream& out) const;
         
         /// Read the path (in the format written by serialize()) from an in stream.
         void deserialize(istream& in);
@@ -407,10 +407,6 @@ private:
     /// The minimum ID in the graph
     nid_t min_id = numeric_limits<nid_t>::max();
     
-    /// The node ID offset accumulated from increment_node_ids. Applied
-    /// dynamically when looking at handles, and permanently on serialization.
-    nid_t id_offset = 0;
-    
     /// Encodes the graph topology
     hash_map<nid_t, node_t> graph;
     
@@ -422,13 +418,6 @@ private:
     
     /// The next path ID we will assign to a new path
     int64_t next_path_id = 1;
-    
-    /// Get ther internal ID of a handle which is its index into internal data structures.
-    /// Does not have id_offset applied.
-    nid_t get_internal_id(const handle_t& handle) const;
-    
-    /// Convert a handle from an internal handle to a real ID space, serializable handle.
-    static handle_t apply_id_offset(const handle_t& internal, nid_t id_offset);
     
     /// Replace the ID in a handle with a different number
     static handle_t set_id(const handle_t& internal, nid_t new_id);

--- a/src/hash_graph.cpp
+++ b/src/hash_graph.cpp
@@ -28,9 +28,9 @@ namespace bdsg {
     }
     
     handle_t HashGraph::create_handle(const string& sequence, const nid_t& id) {
-        graph[id - id_offset] = node_t(sequence);
-        max_id = max(max_id, id - id_offset);
-        min_id = min(min_id, id - id_offset);
+        graph[id] = node_t(sequence);
+        max_id = max(max_id, id);
+        min_id = min(min_id, id);
         return get_handle(id, false);
     }
     
@@ -47,20 +47,20 @@ namespace bdsg {
         }
        
         if (get_is_reverse(left)) {
-            graph[get_internal_id(left)].left_edges.push_back(right);
+            graph[get_id(left)].left_edges.push_back(right);
         }
         else {
-            graph[get_internal_id(left)].right_edges.push_back(right);
+            graph[get_id(left)].right_edges.push_back(right);
         }
         
         // a reversing self-edge only touches one side of one node, so we only want
         // to add it to a single edge list rather than two
         if (left != flip(right)){
             if (get_is_reverse(right)) {
-                graph[get_internal_id(right)].right_edges.push_back(flip(left));
+                graph[get_id(right)].right_edges.push_back(flip(left));
             }
             else {
-                graph[get_internal_id(right)].left_edges.push_back(flip(left));
+                graph[get_id(right)].left_edges.push_back(flip(left));
             }
         }
     }
@@ -70,11 +70,11 @@ namespace bdsg {
     }
     
     handle_t HashGraph::get_handle(const nid_t& node_id, bool is_reverse) const {
-        return handlegraph::number_bool_packing::pack(node_id - id_offset, is_reverse);
+        return handlegraph::number_bool_packing::pack(node_id, is_reverse);
     }
     
     nid_t HashGraph::get_id(const handle_t& handle) const {
-        return get_internal_id(handle) + id_offset;
+        return handlegraph::number_bool_packing::unpack_number(handle) ;
     }
     
     bool HashGraph::get_is_reverse(const handle_t& handle) const {
@@ -86,19 +86,19 @@ namespace bdsg {
     }
     
     size_t HashGraph::get_length(const handle_t& handle) const {
-        return graph.at(get_internal_id(handle)).sequence.size();
+        return graph.at(get_id(handle)).sequence.size();
     }
     
     string HashGraph::get_sequence(const handle_t& handle) const {
-        return get_is_reverse(handle) ? reverse_complement(graph.at(get_internal_id(handle)).sequence)
-                                      : graph.at(get_internal_id(handle)).sequence;
+        return get_is_reverse(handle) ? reverse_complement(graph.at(get_id(handle)).sequence)
+                                      : graph.at(get_id(handle)).sequence;
     }
     
     bool HashGraph::follow_edges_impl(const handle_t& handle, bool go_left,
                                       const std::function<bool(const handle_t&)>& iteratee) const {
         
-        auto& edge_list = get_is_reverse(handle) != go_left ? graph.at(get_internal_id(handle)).left_edges
-                                                            : graph.at(get_internal_id(handle)).right_edges;
+        auto& edge_list = get_is_reverse(handle) != go_left ? graph.at(get_id(handle)).left_edges
+                                                            : graph.at(get_id(handle)).right_edges;
         
         bool keep_going = true;
         for (auto it = edge_list.begin(); it != edge_list.end() && keep_going; it++) {
@@ -112,26 +112,26 @@ namespace bdsg {
     }
     
     nid_t HashGraph::min_node_id(void) const {
-        return min_id + id_offset;
+        return min_id;
     }
     
     nid_t HashGraph::max_node_id(void) const {
-        return max_id + id_offset;
+        return max_id;
     }
     
     size_t HashGraph::get_degree(const handle_t& handle, bool go_left) const {
-        auto& edge_list = get_is_reverse(handle) != go_left ? graph.at(get_internal_id(handle)).left_edges
-                                                            : graph.at(get_internal_id(handle)).right_edges;
+        auto& edge_list = get_is_reverse(handle) != go_left ? graph.at(get_id(handle)).left_edges
+                                                            : graph.at(get_id(handle)).right_edges;
         return edge_list.size();
     }
     
     char HashGraph::get_base(const handle_t& handle, size_t index) const {
-        const string& seq = graph.at(get_internal_id(handle)).sequence;
+        const string& seq = graph.at(get_id(handle)).sequence;
         return get_is_reverse(handle) ? reverse_complement(seq.at(seq.size() - index - 1)) : seq.at(index);
     }
     
     string HashGraph::get_subsequence(const handle_t& handle, size_t index, size_t size) const {
-        const string& seq = graph.at(get_internal_id(handle)).sequence;
+        const string& seq = graph.at(get_id(handle)).sequence;
         size = min(size, seq.size() - index);
         return get_is_reverse(handle) ? reverse_complement(seq.substr(seq.size() - index - size, size)) : seq.substr(index, size);
     }
@@ -174,16 +174,16 @@ namespace bdsg {
         }
         
         // reverse the sequence
-        node_t& node = graph[get_internal_id(handle)];
+        node_t& node = graph[get_id(handle)];
         node.sequence = reverse_complement(node.sequence);
         
         // reverse the orientation of the handle in the edge lists
         for (vector<handle_t>* edge_list : {&node.left_edges, &node.right_edges}) {
             for (const handle_t& target : *edge_list) {
-                node_t& other_node = graph[get_internal_id(target)];
+                node_t& other_node = graph[get_id(target)];
                 auto& bwd_edge_list = get_is_reverse(target) ? other_node.right_edges : other_node.left_edges;
                 for (handle_t& bwd_handle : bwd_edge_list) {
-                    if (get_internal_id(bwd_handle) == get_internal_id(handle)) {
+                    if (get_id(bwd_handle) == get_id(handle)) {
                         bwd_handle = flip(bwd_handle);
                         break;
                     }
@@ -230,20 +230,20 @@ namespace bdsg {
         // divvy up the sequence onto separate nodes
         for (size_t i = 0; i < forward_offsets.size(); i++) {
             size_t length = (i + 1 < forward_offsets.size() ? forward_offsets[i + 1] : node_length) - forward_offsets[i];
-            return_val.push_back(create_handle(graph[get_internal_id(handle)].sequence.substr(forward_offsets[i], length)));
+            return_val.push_back(create_handle(graph[get_id(handle)].sequence.substr(forward_offsets[i], length)));
         }
-        graph[get_internal_id(handle)].sequence = graph[get_internal_id(handle)].sequence.substr(0, forward_offsets.front());
+        graph[get_id(handle)].sequence = graph[get_id(handle)].sequence.substr(0, forward_offsets.front());
         
         // move the edges out the end of the node to the final one
-        node_t& final_node = graph[get_internal_id(return_val.back())];
-        final_node.right_edges = move(graph[get_internal_id(handle)].right_edges);
-        graph[get_internal_id(handle)].right_edges.clear();
+        node_t& final_node = graph[get_id(return_val.back())];
+        final_node.right_edges = move(graph[get_id(handle)].right_edges);
+        graph[get_id(handle)].right_edges.clear();
         
         // update the backwards references back onto this node
         for (const handle_t& next : final_node.right_edges) {
             for (handle_t& bwd_target : get_is_reverse(next) ?
-                                        graph[get_internal_id(next)].right_edges :
-                                        graph[get_internal_id(next)].left_edges) {
+                                        graph[get_id(next)].right_edges :
+                                        graph[get_id(next)].left_edges) {
                 if (bwd_target == flip(forward_handle)) {
                     bwd_target = flip(return_val.back());
                     break;
@@ -257,19 +257,19 @@ namespace bdsg {
         }
         
         // update the paths and the occurrence records
-        for (path_mapping_t* mapping : graph[get_internal_id(handle)].occurrences) {
+        for (path_mapping_t* mapping : graph[get_id(handle)].occurrences) {
             path_t& path = paths[mapping->path_id];
             if (get_is_reverse(mapping->handle)) {
                 for (size_t i = return_val.size() - 1; i > 0; i--) {
                     path_mapping_t* new_mapping = path.insert_before(flip(return_val[i]), mapping);
-                    graph[get_internal_id(return_val[i])].occurrences.push_back(new_mapping);
+                    graph[get_id(return_val[i])].occurrences.push_back(new_mapping);
                 }
             }
             else {
                 mapping = mapping->next;
                 for (size_t i = 1; i < return_val.size(); i++) {
                     path_mapping_t* new_mapping = path.insert_before(return_val[i], mapping);
-                    graph[get_internal_id(return_val[i])].occurrences.push_back(new_mapping);
+                    graph[get_id(return_val[i])].occurrences.push_back(new_mapping);
                 }
             }
         }
@@ -307,12 +307,12 @@ namespace bdsg {
     void HashGraph::destroy_handle(const handle_t& handle) {
         
         // remove backwards references from edges on other nodes
-        node_t& node = graph[get_internal_id(handle)];
+        node_t& node = graph[get_id(handle)];
         for (vector<handle_t>* edge_list : {&node.left_edges, &node.right_edges}) {
             for (const handle_t& next : *edge_list) {
-                auto& bwd_edge_list = get_is_reverse(next) ? graph[get_internal_id(next)].right_edges : graph[get_internal_id(next)].left_edges;
+                auto& bwd_edge_list = get_is_reverse(next) ? graph[get_id(next)].right_edges : graph[get_id(next)].left_edges;
                 for (handle_t& bwd_target : bwd_edge_list) {
-                    if (get_internal_id(bwd_target) == get_internal_id(handle)) {
+                    if (get_id(bwd_target) == get_id(handle)) {
                         bwd_target = bwd_edge_list.back();
                         bwd_edge_list.pop_back();
                         break;
@@ -322,13 +322,13 @@ namespace bdsg {
         }
         
         // remove this node from the relevant indexes
-        graph.erase(get_internal_id(handle));
+        graph.erase(get_id(handle));
     }
     
     void HashGraph::destroy_edge(const handle_t& left, const handle_t& right) {
         
         // remove this edge from left
-        node_t& left_node = graph[get_internal_id(left)];
+        node_t& left_node = graph[get_id(left)];
         auto& left_edge_list = get_is_reverse(left) ? left_node.left_edges : left_node.right_edges;
         
         for (handle_t& next : left_edge_list) {
@@ -340,7 +340,7 @@ namespace bdsg {
         }
         
         // remove this edge from right
-        node_t& right_node = graph[get_internal_id(right)];
+        node_t& right_node = graph[get_id(right)];
         auto& right_edge_list = get_is_reverse(right) ? right_node.right_edges : right_node.left_edges;
         
         for (handle_t& prev : right_edge_list) {
@@ -355,7 +355,6 @@ namespace bdsg {
     void HashGraph::clear(void) {
         max_id = 0;
         min_id = numeric_limits<nid_t>::max();
-        id_offset = 0;
         next_path_id = 1;
         graph.clear();
         path_id.clear();
@@ -454,7 +453,7 @@ namespace bdsg {
     
     bool HashGraph::for_each_step_on_handle_impl(const handle_t& handle,
                                                  const function<bool(const step_handle_t&)>& iteratee) const {
-        for (path_mapping_t* mapping : graph.at(get_internal_id(handle)).occurrences) {
+        for (path_mapping_t* mapping : graph.at(get_id(handle)).occurrences) {
             step_handle_t step;
             as_integers(step)[0] = mapping->path_id;
             as_integers(step)[1] = intptr_t(mapping);
@@ -471,7 +470,7 @@ namespace bdsg {
         // remove the records of nodes occurring on this path
         for_each_step_in_path(path, [&](const step_handle_t& step) {
             path_mapping_t* mapping = (path_mapping_t*) intptr_t(as_integers(step)[1]);
-            vector<path_mapping_t*>& node_occs = graph[get_internal_id(mapping->handle)].occurrences;
+            vector<path_mapping_t*>& node_occs = graph[get_id(mapping->handle)].occurrences;
             for (size_t i = 0; i < node_occs.size(); i++) {
                 if (node_occs[i] == mapping) {
                     node_occs[i] = node_occs.back();
@@ -497,7 +496,7 @@ namespace bdsg {
         
         path_t& path_list = paths[as_integer(path)];
         path_mapping_t* mapping = path_list.push_back(to_append);
-        graph[get_internal_id(to_append)].occurrences.push_back(mapping);
+        graph[get_id(to_append)].occurrences.push_back(mapping);
         
         step_handle_t step;
         as_integers(step)[0] = as_integer(path);
@@ -509,7 +508,7 @@ namespace bdsg {
         
         path_t& path_list = paths[as_integer(path)];
         path_mapping_t* mapping = path_list.push_front(to_prepend);
-        graph[get_internal_id(to_prepend)].occurrences.push_back(mapping);
+        graph[get_id(to_prepend)].occurrences.push_back(mapping);
         
         step_handle_t step;
         as_integers(step)[0] = as_integer(path);
@@ -534,7 +533,7 @@ namespace bdsg {
         for (path_mapping_t* mapping = begin; mapping != end;) {
             
             // remove this occurrence of the mapping from the occurrences index
-            auto& node_occurrences = graph[get_internal_id(mapping->handle)].occurrences;
+            auto& node_occurrences = graph[get_id(mapping->handle)].occurrences;
             for (size_t i = 0; i < node_occurrences.size(); ++i){
                 if (node_occurrences[i] == mapping) {
                     node_occurrences[i] = node_occurrences.back();
@@ -559,7 +558,7 @@ namespace bdsg {
         for (const handle_t& handle : new_segment) {
             
             path_mapping_t* mapping = path_list.insert_before(handle, end);
-            graph[get_internal_id(handle)].occurrences.push_back(mapping);
+            graph[get_id(handle)].occurrences.push_back(mapping);
             
             if (first_iter) {
                 as_integers(new_range.first)[1] = intptr_t(mapping);
@@ -593,7 +592,7 @@ namespace bdsg {
     }
 
     void HashGraph::increment_node_ids(nid_t increment) {
-        id_offset += increment; 
+        reassign_node_ids([&increment](const nid_t& node_id) { return node_id + increment; });
     }
     
     void HashGraph::reassign_node_ids(const std::function<nid_t(const nid_t&)>& get_new_id) {
@@ -603,14 +602,13 @@ namespace bdsg {
         nid_t new_max_id = 0;
         nid_t new_min_id = std::numeric_limits<nid_t>::max();
         
-        // We also need to make sure to respect id_offset when calling the translation function.
         auto it = graph.begin();
         while (it != graph.end()) {
             // For each node we have
             auto& record = it->second;
             
             // Convert its ID
-            nid_t new_id = get_new_id(it->first + id_offset);
+            nid_t new_id = get_new_id(it->first);
             new_max_id = std::max(new_max_id, new_id);
             new_min_id = std::min(new_min_id, new_id);
             
@@ -654,7 +652,6 @@ namespace bdsg {
         // Now apply the graph metadata (and zero the ID offset).
         max_id = new_max_id;
         min_id = new_min_id;
-        id_offset = 0;
     }
     
     HashGraph::path_t::path_t() {
@@ -850,7 +847,7 @@ namespace bdsg {
         return inserting;
     }
     
-    void HashGraph::path_t::serialize(ostream& out, nid_t id_offset) const {
+    void HashGraph::path_t::serialize(ostream& out) const {
         
         out.write((const char*) &is_circular, sizeof(is_circular) / sizeof(char));
         
@@ -868,7 +865,7 @@ namespace bdsg {
         path_mapping_t* mapping = head;
         bool first_iter = true;
         while (mapping && (first_iter || mapping != head)) { // extra condition for circular paths
-            int64_t step = endianness<int64_t>::to_big_endian(as_integer(apply_id_offset(mapping->handle, id_offset)));
+            int64_t step = endianness<int64_t>::to_big_endian(as_integer(mapping->handle));
 
             out.write((const char*) &step, sizeof(step) / sizeof(char));
             mapping = mapping->next;
@@ -909,7 +906,7 @@ namespace bdsg {
         }
     }
     
-    void HashGraph::node_t::serialize(ostream& out, nid_t id_offset) const {
+    void HashGraph::node_t::serialize(ostream& out) const {
         
         uint64_t seq_size_out = endianness<uint64_t>::to_big_endian( sequence.size());
         out.write((const char*) &seq_size_out, sizeof(seq_size_out) / sizeof(char));
@@ -918,14 +915,14 @@ namespace bdsg {
         uint64_t left_edges_size_out = endianness<uint64_t>::to_big_endian(left_edges.size());
         out.write((const char*) &left_edges_size_out, sizeof(left_edges_size_out) / sizeof(char));
         for (size_t i = 0; i < left_edges.size(); i++) {
-            int64_t next_out = endianness<int64_t>::to_big_endian(as_integer(apply_id_offset(left_edges[i], id_offset))); 
+            int64_t next_out = endianness<int64_t>::to_big_endian(as_integer(left_edges[i]));
             out.write((const char*) &next_out, sizeof(next_out) / sizeof(char));
         }
         
         uint64_t right_edges_size_out = endianness<uint64_t>::to_big_endian(right_edges.size());
         out.write((const char*) &right_edges_size_out, sizeof(right_edges_size_out) / sizeof(char));
         for (size_t i = 0; i < right_edges.size(); i++) {
-            int64_t next_out = endianness<int64_t>::to_big_endian(as_integer(apply_id_offset(right_edges[i], id_offset)));
+            int64_t next_out = endianness<int64_t>::to_big_endian(as_integer(right_edges[i]));
             out.write((const char*) &next_out, sizeof(next_out) / sizeof(char));
         }
         
@@ -967,10 +964,10 @@ namespace bdsg {
     }
     
     void HashGraph::serialize_members(ostream& out) const {
-        nid_t max_id_out = endianness<nid_t>::to_big_endian(max_id +  id_offset);
+        nid_t max_id_out = endianness<nid_t>::to_big_endian(max_id);
         out.write((const char*) &max_id_out, sizeof(max_id_out) / sizeof(char));
         
-        nid_t min_id_out = endianness<nid_t>::to_big_endian(min_id + id_offset);
+        nid_t min_id_out = endianness<nid_t>::to_big_endian(min_id);
         out.write((const char*) &min_id_out, sizeof(min_id_out) / sizeof(char));
         
         int64_t next_path_id_out = endianness<int64_t>::to_big_endian(next_path_id);
@@ -980,15 +977,15 @@ namespace bdsg {
         out.write((const char*) &graph_size_out, sizeof(graph_size_out) / sizeof(char));
         
         for (const pair<nid_t, node_t>& node_record : graph) {
-            nid_t node_id_out = endianness<nid_t>::to_big_endian(node_record.first + id_offset);
+            nid_t node_id_out = endianness<nid_t>::to_big_endian(node_record.first);
             out.write((const char*) &node_id_out, sizeof(node_id_out) / sizeof(char));
-            node_record.second.serialize(out, id_offset);
+            node_record.second.serialize(out);
         }
         
         uint64_t paths_size_out = endianness<uint64_t>::to_big_endian(paths.size());
         out.write((const char*) &paths_size_out, sizeof(paths_size_out) / sizeof(char));
         for (const pair<int64_t, path_t>& path_record : paths) {
-            path_record.second.serialize(out, id_offset);
+            path_record.second.serialize(out);
         }
     }
     
@@ -1041,7 +1038,7 @@ namespace bdsg {
                  mapping != nullptr && (first_iter || mapping != path.head); // for circular paths
                  mapping = mapping->next) {
                 
-                graph[get_internal_id(mapping->handle)].occurrences.push_back(mapping);
+                graph[get_id(mapping->handle)].occurrences.push_back(mapping);
                 first_iter = false;
             }
         }
@@ -1051,18 +1048,8 @@ namespace bdsg {
         return 676155192ul;
     }
     
-    nid_t HashGraph::get_internal_id(const handle_t& handle) const {
-        return handlegraph::number_bool_packing::unpack_number(handle);
-    }
-    
-    handle_t HashGraph::apply_id_offset(const handle_t& internal, nid_t id_offset) {
-        nid_t node_id = handlegraph::number_bool_packing::unpack_number(internal);
-        bool is_reverse = handlegraph::number_bool_packing::unpack_bit(internal);
-        return handlegraph::number_bool_packing::pack(node_id + id_offset, is_reverse);
-    }
-    
-    handle_t HashGraph::set_id(const handle_t& internal, nid_t new_id) {
-        bool is_reverse = handlegraph::number_bool_packing::unpack_bit(internal);
+    handle_t HashGraph::set_id(const handle_t& handle, nid_t new_id) {
+        bool is_reverse = handlegraph::number_bool_packing::unpack_bit(handle);
         return handlegraph::number_bool_packing::pack(new_id, is_reverse);
     }
     


### PR DESCRIPTION
Resolves https://github.com/vgteam/libbdsg/issues/51.

The `increment_node_ids` is done through `reassign_node_ids` now, which is O(N) instead of O(1), but I think we were probably paying nearly a high running costs over time. They were just spread out over many function calls rather than right at the time of reassignment. Also, this doesn't crash.