### PR TITLE
Harmonize set_id_increment semantics

### DIFF
--- a/src/test_libbdsg.cpp
+++ b/src/test_libbdsg.cpp
@@ -96,7 +96,7 @@ void test_deletable_handle_graphs() {
         implementations.push_back(&hg);
 
         ODGI og;
-        //implementations.push_back(&og);
+        implementations.push_back(&og);
         
         // And test them
         
@@ -1157,7 +1157,7 @@ void test_deletable_handle_graphs() {
         implementations.push_back(&hg);
         
         ODGI og;
-        //implementations.push_back(&og);
+        implementations.push_back(&og);
         
         for (DeletableHandleGraph* implementation : implementations) {
             
@@ -2608,11 +2608,12 @@ void test_vectorizable_overlays() {
     
     bdsg::PackedGraph pg;
     bdsg::HashGraph hg;
+    bdsg::ODGI og;
     
     vector<MutablePathDeletableHandleGraph*> implementations;
     implementations.push_back(&pg);
     implementations.push_back(&hg);
-    //implementations.push_back(&og);
+    implementations.push_back(&og);
     
     for (MutablePathDeletableHandleGraph* implementation : implementations) {
         


### PR DESCRIPTION
We originally wanted `set_id_increment` to have a viable no-op implementation, but the ODGI implementation didn't allow for that because it expected future calls to `create_handle` to be cognizant of the increment value. I made it so that the increment value is applied automatically on creating handles so that the construction semantics remain the same with or without calling `set_id_increment`.

I also noticed that ODGI wasn't being run through some of the tests, so I restored them. The path tests are actually not passing though.