### PR TITLE
Don't make the rank of the first node -1

### DIFF
--- a/include/bdsg/odgi.hpp
+++ b/include/bdsg/odgi.hpp
@@ -486,10 +486,10 @@ private:
     void set_handle_sequence(const handle_t& handle, const std::string& seq);
 
     /// get the backing node rank for a given node id
-    uint64_t get_node_rank(const nid_t& node_id) const;
+    uint64_t id_to_rank(const nid_t& node_id) const;
     
     /// get the node id for the node with the given backing rank
-    nid_t get_rank_node(const uint64_t& rank) const;
+    nid_t rank_to_id(const uint64_t& rank) const;
 
 };
 

--- a/include/bdsg/odgi.hpp
+++ b/include/bdsg/odgi.hpp
@@ -396,10 +396,12 @@ private:
     suc_bv deleted_node_bv;
     uint64_t _deleted_node_count = 0;
     // efficient id to handle/sequence conversion
-    /// Max rank (distance above _id_increment) of a node in the graph
+    /// Max rank (distance above _id_increment) of a node in the graph.
+    /// 0 if the graph is empty.
     uint64_t _max_node_rank = 0;
-    /// Min rank (distance above _id_increment) of a node in the graph
-    uint64_t _min_node_rank = 0;
+    /// Min rank (distance above _id_increment) of a node in the graph.
+    /// Maximum possible value if the graph is empty, for easy min().
+    uint64_t _min_node_rank = std::numeric_limits<decltype(_min_node_rank)>::max();
     nid_t _id_increment = 0;
     /// records nodes that are hidden, but used to compactly store path sequence that has been removed from the node space
     hash_set<uint64_t> graph_id_hidden_set;

--- a/include/bdsg/odgi.hpp
+++ b/include/bdsg/odgi.hpp
@@ -395,9 +395,11 @@ private:
     /// Mark deleted nodes here for translating graph ids into internal ranks
     suc_bv deleted_node_bv;
     uint64_t _deleted_node_count = 0;
-    /// efficient id to handle/sequence conversion
-    nid_t _max_node_id = 0;
-    nid_t _min_node_id = 0;
+    // efficient id to handle/sequence conversion
+    /// Max rank (distance above _id_increment) of a node in the graph
+    uint64_t _max_node_rank = 0;
+    /// Min rank (distance above _id_increment) of a node in the graph
+    uint64_t _min_node_rank = 0;
     nid_t _id_increment = 0;
     /// records nodes that are hidden, but used to compactly store path sequence that has been removed from the node space
     hash_set<uint64_t> graph_id_hidden_set;
@@ -485,6 +487,9 @@ private:
 
     /// get the backing node rank for a given node id
     uint64_t get_node_rank(const nid_t& node_id) const;
+    
+    /// get the node id for the node with the given backing rank
+    nid_t get_rank_node(const uint64_t& rank) const;
 
 };
 

--- a/include/bdsg/odgi.hpp
+++ b/include/bdsg/odgi.hpp
@@ -275,7 +275,7 @@ public:
         destroy_edge(edge.first, edge.second);
     }
     
-    /// Remove all nodes and edges. Does not update any stored paths.
+    /// Remove all nodes, edges, and paths. 
     void clear(void);
 
     /// Remove all stored paths
@@ -402,7 +402,9 @@ private:
     /// Min rank (distance above _id_increment) of a node in the graph.
     /// Maximum possible value if the graph is empty, for easy min().
     uint64_t _min_node_rank = std::numeric_limits<decltype(_min_node_rank)>::max();
-    nid_t _id_increment = 0;
+    /// ID of the lowest-rank (rank 0) node.
+    /// Must be at least 1, or else the rank 0 node can't exist.
+    nid_t _id_increment = 1;
     /// records nodes that are hidden, but used to compactly store path sequence that has been removed from the node space
     hash_set<uint64_t> graph_id_hidden_set;
 
@@ -480,6 +482,13 @@ private:
 
     /// Decrement the step rank references for this step
     void decrement_rank(const step_handle_t& step_handle);
+    
+    /// Modify the given step handle to point to the given handle.
+    void set_handle_of_step(step_handle_t& step_handle, const handle_t& handle) const;
+    
+    /// Add the offset to the number packed in the given handle, and return a
+    /// new modified handle.
+    handle_t add_to_number(const handle_t& handle, int64_t offset) const;
 
     /// Compact away the deleted nodes info
     //void rebuild_id_handle_mapping(void);

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -31,12 +31,12 @@ handle_t ODGI::get_handle(const nid_t& node_id, bool is_reverse) const {
 
 /// Get the ID from a handle
 nid_t ODGI::get_id(const handle_t& handle) const {
-    return number_bool_packing::unpack_number(handle) + 1 + _id_increment;
+    return number_bool_packing::unpack_number(handle) + _id_increment;
 }
 
 /// get the backing node for a given node id
 uint64_t ODGI::get_node_rank(const nid_t& node_id) const {
-    return node_id - _id_increment - 1;
+    return node_id - _id_increment;
 }
 
 /// set the id increment, used when the graph starts at a high id to reduce loading costs
@@ -433,9 +433,9 @@ void ODGI::for_each_step_in_path(const path_handle_t& path, const std::function<
 handle_t ODGI::create_handle(const std::string& sequence) {
     // get first deleted node to recycle
     if (_deleted_node_count) {
-        return create_handle(sequence, deleted_node_bv.select1(0)+1);
+        return create_handle(sequence, deleted_node_bv.select1(0)+_id_increment);
     } else {
-        return create_handle(sequence, node_v.size()+1);
+        return create_handle(sequence, node_v.size()+_id_increment);
     }
 }
 

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -475,8 +475,9 @@ handle_t ODGI::create_handle(const std::string& sequence, const nid_t& id) {
     } else {
         _min_node_id = internal_id;
     }
+    // Give the node a rank. We can just use the internal ID, since that starts at 0.
+    uint64_t handle_rank = (uint64_t)internal_id;
     // add to node vector
-    uint64_t handle_rank = (uint64_t)internal_id-1;
     // set its values
     auto& node = node_v[handle_rank];
     node.set_sequence(sequence);

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -469,14 +469,15 @@ handle_t ODGI::create_handle(const std::string& sequence, const nid_t& id) {
     // Give the node a rank, which is just how far above _id_increment it is.
     uint64_t handle_rank = get_rank_node(id);
     
-    if (handle_rank > node_v.size()) {
-        uint64_t to_add = handle_rank - node_v.size();
+    if (handle_rank >= node_v.size()) {
         uint64_t old_size = node_v.size();
-        // realloc
-        node_v.resize(handle_rank);
+        // realloc to have a last entry handle_rank
+        node_v.resize(handle_rank + 1);
         _node_count = node_v.size();
+        
         // mark empty nodes (treat them as deleted)
-        for (uint64_t i = 0; i < to_add; ++i) {
+        uint64_t added = _node_count - old_size;
+        for (uint64_t i = 0; i < added; ++i) {
             // insert before final delimiter
             deleted_node_bv.insert(old_size, 1);
             ++_deleted_node_count;

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -20,13 +20,13 @@ uint32_t ODGI::get_magic_number() const {
 
 /// Method to check if a node exists by ID
 bool ODGI::has_node(nid_t node_id) const {
-    uint64_t rank = get_node_rank(node_id);
+    uint64_t rank = id_to_rank(node_id);
     return (rank >= node_v.size() ? false : !deleted_node_bv.at(rank));
 }
 
 /// Look up the handle for the node with the given ID in the given orientation
 handle_t ODGI::get_handle(const nid_t& node_id, bool is_reverse) const {
-    return number_bool_packing::pack(get_node_rank(node_id), is_reverse);
+    return number_bool_packing::pack(id_to_rank(node_id), is_reverse);
 }
 
 /// Get the ID from a handle
@@ -35,12 +35,12 @@ nid_t ODGI::get_id(const handle_t& handle) const {
 }
 
 /// get the backing node rank for a given node id
-uint64_t ODGI::get_node_rank(const nid_t& node_id) const {
+uint64_t ODGI::id_to_rank(const nid_t& node_id) const {
     return node_id - _id_increment;
 }
 
 /// get the node id for the node with the given backing rank
-nid_t ODGI::get_rank_node(const uint64_t& rank) const {
+nid_t ODGI::rank_to_id(const uint64_t& rank) const {
     return rank + _id_increment;
 }
 
@@ -154,13 +154,13 @@ size_t ODGI::get_node_count(void) const {
 /// Return the smallest ID in the graph, or some smaller number if the
 /// smallest ID is unavailable. Return value is unspecified if the graph is empty.
 nid_t ODGI::min_node_id(void) const {
-    return get_rank_node(_min_node_rank);
+    return rank_to_id(_min_node_rank);
 }
     
 /// Return the largest ID in the graph, or some larger number if the
 /// largest ID is unavailable. Return value is unspecified if the graph is empty.
 nid_t ODGI::max_node_id(void) const {
-    return get_rank_node(_max_node_rank);
+    return rank_to_id(_max_node_rank);
 }
     
 ////////////////////////////////////////////////////////////////////////////
@@ -438,9 +438,9 @@ void ODGI::for_each_step_in_path(const path_handle_t& path, const std::function<
 handle_t ODGI::create_handle(const std::string& sequence) {
     // get first deleted node to recycle
     if (_deleted_node_count) {
-        return create_handle(sequence, get_rank_node(deleted_node_bv.select1(0)));
+        return create_handle(sequence, rank_to_id(deleted_node_bv.select1(0)));
     } else {
-        return create_handle(sequence, get_rank_node(node_v.size()));
+        return create_handle(sequence, rank_to_id(node_v.size()));
     }
 }
 
@@ -467,7 +467,7 @@ handle_t ODGI::create_handle(const std::string& sequence, const nid_t& id) {
     }
     
     // Give the node a rank, which is just how far above _id_increment it is.
-    uint64_t handle_rank = get_rank_node(id);
+    uint64_t handle_rank = id_to_rank(id);
     
     if (handle_rank >= node_v.size()) {
         uint64_t old_size = node_v.size();


### PR DESCRIPTION
In #54 we replaced a variable that used to start at 1 with one that now starts at 0, so we need to not subtract 1 from it to get a 0-based rank.