### PR TITLE
Update libhandlegraph and add a truncate implementation

### DIFF
--- a/bdsg/cmake_bindings/bdsg.cpp
+++ b/bdsg/cmake_bindings/bdsg.cpp
@@ -21,7 +21,7 @@ void bind_bdsg_internal_is_single_stranded(std::function< pybind11::module &(std
 void bind_bdsg_odgi(std::function< pybind11::module &(std::string const &namespace_) > &M);
 void bind_handlegraph_path_position_handle_graph(std::function< pybind11::module &(std::string const &namespace_) > &M);
 void bind_bdsg_overlays_packed_path_position_overlay(std::function< pybind11::module &(std::string const &namespace_) > &M);
-void bind_bdsg_overlays_packed_subgraph_overlay(std::function< pybind11::module &(std::string const &namespace_) > &M);
+void bind_bdsg_overlays_packed_path_position_overlay_1(std::function< pybind11::module &(std::string const &namespace_) > &M);
 void bind_bdsg_overlays_path_position_overlays(std::function< pybind11::module &(std::string const &namespace_) > &M);
 void bind_bdsg_overlays_vectorizable_overlays(std::function< pybind11::module &(std::string const &namespace_) > &M);
 void bind_bdsg_overlays_vectorizable_overlays_1(std::function< pybind11::module &(std::string const &namespace_) > &M);
@@ -62,7 +62,7 @@ PYBIND11_MODULE(bdsg, root_module) {
 	bind_bdsg_odgi(M);
 	bind_handlegraph_path_position_handle_graph(M);
 	bind_bdsg_overlays_packed_path_position_overlay(M);
-	bind_bdsg_overlays_packed_subgraph_overlay(M);
+	bind_bdsg_overlays_packed_path_position_overlay_1(M);
 	bind_bdsg_overlays_path_position_overlays(M);
 	bind_bdsg_overlays_vectorizable_overlays(M);
 	bind_bdsg_overlays_vectorizable_overlays_1(M);

--- a/bdsg/cmake_bindings/bdsg.sources
+++ b/bdsg/cmake_bindings/bdsg.sources
@@ -12,7 +12,7 @@ bdsg/internal/is_single_stranded.cpp
 bdsg/odgi.cpp
 handlegraph/path_position_handle_graph.cpp
 bdsg/overlays/packed_path_position_overlay.cpp
-bdsg/overlays/packed_subgraph_overlay.cpp
+bdsg/overlays/packed_path_position_overlay_1.cpp
 bdsg/overlays/path_position_overlays.cpp
 bdsg/overlays/vectorizable_overlays.cpp
 bdsg/overlays/vectorizable_overlays_1.cpp

--- a/bdsg/cmake_bindings/bdsg/internal/packed_structs.cpp
+++ b/bdsg/cmake_bindings/bdsg/internal/packed_structs.cpp
@@ -46,6 +46,8 @@ void bind_bdsg_internal_packed_structs(std::function< pybind11::module &(std::st
 		pybind11::class_<bdsg::PagedVector, std::shared_ptr<bdsg::PagedVector>> cl(M("bdsg"), "PagedVector", "");
 		cl.def( pybind11::init<unsigned long>(), pybind11::arg("page_size") );
 
+		cl.def( pybind11::init( [](bdsg::PagedVector const &o){ return new bdsg::PagedVector(o); } ) );
+		cl.def("assign", (class bdsg::PagedVector & (bdsg::PagedVector::*)(const class bdsg::PagedVector &)) &bdsg::PagedVector::operator=, "Copy assignment operator\n\nC++: bdsg::PagedVector::operator=(const class bdsg::PagedVector &) --> class bdsg::PagedVector &", pybind11::return_value_policy::automatic, pybind11::arg("other"));
 		cl.def("set", (void (bdsg::PagedVector::*)(const unsigned long &, const unsigned long &)) &bdsg::PagedVector::set, "Set the i-th value\n\nC++: bdsg::PagedVector::set(const unsigned long &, const unsigned long &) --> void", pybind11::arg("i"), pybind11::arg("value"));
 		cl.def("get", (unsigned long (bdsg::PagedVector::*)(const unsigned long &) const) &bdsg::PagedVector::get, "Returns the i-th value\n\nC++: bdsg::PagedVector::get(const unsigned long &) const --> unsigned long", pybind11::arg("i"));
 		cl.def("append", (void (bdsg::PagedVector::*)(const unsigned long &)) &bdsg::PagedVector::append, "Add a value to the end\n\nC++: bdsg::PagedVector::append(const unsigned long &) --> void", pybind11::arg("value"));
@@ -58,10 +60,12 @@ void bind_bdsg_internal_packed_structs(std::function< pybind11::module &(std::st
 		cl.def("page_width", (unsigned long (bdsg::PagedVector::*)() const) &bdsg::PagedVector::page_width, "Returns the page width of the vector\n\nC++: bdsg::PagedVector::page_width() const --> unsigned long");
 		cl.def("memory_usage", (unsigned long (bdsg::PagedVector::*)() const) &bdsg::PagedVector::memory_usage, "Reports the amount of memory consumed by this object in bytes\n\nC++: bdsg::PagedVector::memory_usage() const --> unsigned long");
 	}
-	{ // bdsg::RobustPagedVector file:bdsg/internal/packed_structs.hpp line:188
+	{ // bdsg::RobustPagedVector file:bdsg/internal/packed_structs.hpp line:193
 		pybind11::class_<bdsg::RobustPagedVector, std::shared_ptr<bdsg::RobustPagedVector>> cl(M("bdsg"), "RobustPagedVector", "");
 		cl.def( pybind11::init<unsigned long>(), pybind11::arg("page_size") );
 
+		cl.def( pybind11::init( [](bdsg::RobustPagedVector const &o){ return new bdsg::RobustPagedVector(o); } ) );
+		cl.def("assign", (class bdsg::RobustPagedVector & (bdsg::RobustPagedVector::*)(const class bdsg::RobustPagedVector &)) &bdsg::RobustPagedVector::operator=, "Copy assignment operator\n\nC++: bdsg::RobustPagedVector::operator=(const class bdsg::RobustPagedVector &) --> class bdsg::RobustPagedVector &", pybind11::return_value_policy::automatic, pybind11::arg("other"));
 		cl.def("set", (void (bdsg::RobustPagedVector::*)(const unsigned long &, const unsigned long &)) &bdsg::RobustPagedVector::set, "Set the i-th value\n\nC++: bdsg::RobustPagedVector::set(const unsigned long &, const unsigned long &) --> void", pybind11::arg("i"), pybind11::arg("value"));
 		cl.def("get", (unsigned long (bdsg::RobustPagedVector::*)(const unsigned long &) const) &bdsg::RobustPagedVector::get, "Returns the i-th value\n\nC++: bdsg::RobustPagedVector::get(const unsigned long &) const --> unsigned long", pybind11::arg("i"));
 		cl.def("append", (void (bdsg::RobustPagedVector::*)(const unsigned long &)) &bdsg::RobustPagedVector::append, "Add a value to the end\n\nC++: bdsg::RobustPagedVector::append(const unsigned long &) --> void", pybind11::arg("value"));
@@ -74,9 +78,11 @@ void bind_bdsg_internal_packed_structs(std::function< pybind11::module &(std::st
 		cl.def("page_width", (unsigned long (bdsg::RobustPagedVector::*)() const) &bdsg::RobustPagedVector::page_width, "Returns the page width of the vector\n\nC++: bdsg::RobustPagedVector::page_width() const --> unsigned long");
 		cl.def("memory_usage", (unsigned long (bdsg::RobustPagedVector::*)() const) &bdsg::RobustPagedVector::memory_usage, "Reports the amount of memory consumed by this object in bytes\n\nC++: bdsg::RobustPagedVector::memory_usage() const --> unsigned long");
 	}
-	{ // bdsg::PackedDeque file:bdsg/internal/packed_structs.hpp line:260
+	{ // bdsg::PackedDeque file:bdsg/internal/packed_structs.hpp line:270
 		pybind11::class_<bdsg::PackedDeque, std::shared_ptr<bdsg::PackedDeque>> cl(M("bdsg"), "PackedDeque", "");
 		cl.def( pybind11::init( [](){ return new bdsg::PackedDeque(); } ) );
+		cl.def( pybind11::init( [](bdsg::PackedDeque const &o){ return new bdsg::PackedDeque(o); } ) );
+		cl.def("assign", (class bdsg::PackedDeque & (bdsg::PackedDeque::*)(const class bdsg::PackedDeque &)) &bdsg::PackedDeque::operator=, "Copy assignment operator\n\nC++: bdsg::PackedDeque::operator=(const class bdsg::PackedDeque &) --> class bdsg::PackedDeque &", pybind11::return_value_policy::automatic, pybind11::arg("other"));
 		cl.def("set", (void (bdsg::PackedDeque::*)(const unsigned long &, const unsigned long &)) &bdsg::PackedDeque::set, "Set the i-th value\n\nC++: bdsg::PackedDeque::set(const unsigned long &, const unsigned long &) --> void", pybind11::arg("i"), pybind11::arg("value"));
 		cl.def("get", (unsigned long (bdsg::PackedDeque::*)(const unsigned long &) const) &bdsg::PackedDeque::get, "Returns the i-th value\n\nC++: bdsg::PackedDeque::get(const unsigned long &) const --> unsigned long", pybind11::arg("i"));
 		cl.def("append_front", (void (bdsg::PackedDeque::*)(const unsigned long &)) &bdsg::PackedDeque::append_front, "Add a value to the front\n\nC++: bdsg::PackedDeque::append_front(const unsigned long &) --> void", pybind11::arg("value"));
@@ -89,9 +95,9 @@ void bind_bdsg_internal_packed_structs(std::function< pybind11::module &(std::st
 		cl.def("clear", (void (bdsg::PackedDeque::*)()) &bdsg::PackedDeque::clear, "Empty the contents\n\nC++: bdsg::PackedDeque::clear() --> void");
 		cl.def("memory_usage", (unsigned long (bdsg::PackedDeque::*)() const) &bdsg::PackedDeque::memory_usage, "Reports the amount of memory consumed by this object in bytes.\n\nC++: bdsg::PackedDeque::memory_usage() const --> unsigned long");
 	}
-	{ // bdsg::PackedSet file:bdsg/internal/packed_structs.hpp line:334
+	{ // bdsg::PackedSet file:bdsg/internal/packed_structs.hpp line:349
 		pybind11::class_<bdsg::PackedSet, std::shared_ptr<bdsg::PackedSet>> cl(M("bdsg"), "PackedSet", "");
-		{ // bdsg::PackedSet::iterator file:bdsg/internal/packed_structs.hpp line:388
+		{ // bdsg::PackedSet::iterator file:bdsg/internal/packed_structs.hpp line:403
 			auto & enclosing_class = cl;
 			pybind11::class_<bdsg::PackedSet::iterator, std::shared_ptr<bdsg::PackedSet::iterator>> cl(enclosing_class, "iterator", "");
 			cl.def( pybind11::init( [](bdsg::PackedSet::iterator const &o){ return new bdsg::PackedSet::iterator(o); } ) );

--- a/bdsg/cmake_bindings/bdsg/internal/utility.cpp
+++ b/bdsg/cmake_bindings/bdsg/internal/utility.cpp
@@ -2,6 +2,7 @@
 #include <bdsg/internal/utility.hpp>
 #include <functional>
 #include <handlegraph/handle_graph.hpp>
+#include <handlegraph/mutable_handle_graph.hpp>
 #include <handlegraph/path_handle_graph.hpp>
 #include <handlegraph/types.hpp>
 #include <ios>
@@ -294,6 +295,19 @@ struct PyCallBack_bdsg_HashGraph : public bdsg::HashGraph {
 			else return pybind11::detail::cast_safe<void>(std::move(o));
 		}
 		return HashGraph::destroy_edge(a0, a1);
+	}
+	struct handlegraph::handle_t truncate_handle(const struct handlegraph::handle_t & a0, bool a1, unsigned long a2) override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::HashGraph *>(this), "truncate_handle");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0, a1, a2);
+			if (pybind11::detail::cast_is_temporary_value_reference<struct handlegraph::handle_t>::value) {
+				static pybind11::detail::overload_caster_t<struct handlegraph::handle_t> caster;
+				return pybind11::detail::cast_ref<struct handlegraph::handle_t>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<struct handlegraph::handle_t>(std::move(o));
+		}
+		return HashGraph::truncate_handle(a0, a1, a2);
 	}
 	void clear() override { 
 		pybind11::gil_scoped_acquire gil;
@@ -725,6 +739,19 @@ struct PyCallBack_bdsg_HashGraph : public bdsg::HashGraph {
 		}
 		return HashGraph::get_magic_number();
 	}
+	unsigned long get_step_count(const struct handlegraph::handle_t & a0) const override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::HashGraph *>(this), "get_step_count");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<unsigned long>::value) {
+				static pybind11::detail::overload_caster_t<unsigned long> caster;
+				return pybind11::detail::cast_ref<unsigned long>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<unsigned long>(std::move(o));
+		}
+		return PathHandleGraph::get_step_count(a0);
+	}
 	class std::vector<handlegraph::step_handle_t> steps_of_handle(const struct handlegraph::handle_t & a0, bool a1) const override { 
 		pybind11::gil_scoped_acquire gil;
 		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::HashGraph *>(this), "steps_of_handle");
@@ -789,6 +816,19 @@ struct PyCallBack_bdsg_HashGraph : public bdsg::HashGraph {
 			else return pybind11::detail::cast_safe<unsigned long>(std::move(o));
 		}
 		return HandleGraph::get_total_length();
+	}
+	void increment_node_ids(long a0) override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::HashGraph *>(this), "increment_node_ids");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<void>::value) {
+				static pybind11::detail::overload_caster_t<void> caster;
+				return pybind11::detail::cast_ref<void>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<void>(std::move(o));
+		}
+		return MutableHandleGraph::increment_node_ids(a0);
 	}
 };
 
@@ -857,6 +897,7 @@ void bind_bdsg_internal_utility(std::function< pybind11::module &(std::string co
 		cl.def("destroy_handle", (void (bdsg::HashGraph::*)(const struct handlegraph::handle_t &)) &bdsg::HashGraph::destroy_handle, "Remove the node belonging to the given handle and all of its edges.\n Destroys any paths in which the node participates.\n Invalidates the destroyed handle.\n May be called during serial for_each_handle iteration **ONLY** on the node being iterated.\n May **NOT** be called during parallel for_each_handle iteration.\n May **NOT** be called on the node from which edges are being followed during follow_edges.\n May **NOT** be called during iteration over paths, if it would destroy a path.\n May **NOT** be called during iteration along a path, if it would destroy that path.\n\nC++: bdsg::HashGraph::destroy_handle(const struct handlegraph::handle_t &) --> void", pybind11::arg("handle"));
 		cl.def("create_edge", (void (bdsg::HashGraph::*)(const struct handlegraph::handle_t &, const struct handlegraph::handle_t &)) &bdsg::HashGraph::create_edge, "Create an edge connecting the given handles in the given order and orientations.\n Ignores existing edges.\n\nC++: bdsg::HashGraph::create_edge(const struct handlegraph::handle_t &, const struct handlegraph::handle_t &) --> void", pybind11::arg("left"), pybind11::arg("right"));
 		cl.def("destroy_edge", (void (bdsg::HashGraph::*)(const struct handlegraph::handle_t &, const struct handlegraph::handle_t &)) &bdsg::HashGraph::destroy_edge, "Remove the edge connecting the given handles in the given order and orientations.\n Ignores nonexistent edges.\n Does not update any stored paths.\n\nC++: bdsg::HashGraph::destroy_edge(const struct handlegraph::handle_t &, const struct handlegraph::handle_t &) --> void", pybind11::arg("left"), pybind11::arg("right"));
+		cl.def("truncate_handle", (struct handlegraph::handle_t (bdsg::HashGraph::*)(const struct handlegraph::handle_t &, bool, unsigned long)) &bdsg::HashGraph::truncate_handle, "Shorten a node by truncating either the left or right side of the node, relative to the orientation\n of the handle, starting from a given offset along the nodes sequence. Any edges on the truncated\n end of the node are deleted. Returns a (possibly altered) handle to the truncated node.\n May invalid stored paths.\n\nC++: bdsg::HashGraph::truncate_handle(const struct handlegraph::handle_t &, bool, unsigned long) --> struct handlegraph::handle_t", pybind11::arg("handle"), pybind11::arg("trunc_left"), pybind11::arg("offset"));
 		cl.def("clear", (void (bdsg::HashGraph::*)()) &bdsg::HashGraph::clear, "Remove all nodes and edges. Does not update any stored paths.\n\nC++: bdsg::HashGraph::clear() --> void");
 		cl.def("apply_orientation", (struct handlegraph::handle_t (bdsg::HashGraph::*)(const struct handlegraph::handle_t &)) &bdsg::HashGraph::apply_orientation, "Alter the node that the given handle corresponds to so the orientation\n indicated by the handle becomes the node's local forward orientation.\n Rewrites all edges pointing to the node and the node's sequence to\n reflect this. Invalidates all handles to the node (including the one\n passed). Returns a new, valid handle to the node in its new forward\n orientation. Note that it is possible for the node's ID to change.\n Does not update any stored paths. May change the ordering of the underlying\n graph.\n\nC++: bdsg::HashGraph::apply_orientation(const struct handlegraph::handle_t &) --> struct handlegraph::handle_t", pybind11::arg("handle"));
 		cl.def("divide_handle", (class std::vector<handlegraph::handle_t> (bdsg::HashGraph::*)(const struct handlegraph::handle_t &, const class std::vector<unsigned long> &)) &bdsg::HashGraph::divide_handle, "Split a handle's underlying node at the given offsets in the handle's\n orientation. Returns all of the handles to the parts. Other handles to\n the node being split may be invalidated. The split pieces stay in the\n same local forward orientation as the original node, but the returned\n handles come in the order and orientation appropriate for the handle\n passed in.\n Updates stored paths.\n\nC++: bdsg::HashGraph::divide_handle(const struct handlegraph::handle_t &, const class std::vector<unsigned long> &) --> class std::vector<handlegraph::handle_t>", pybind11::arg("handle"), pybind11::arg("offsets"));

--- a/bdsg/cmake_bindings/bdsg/odgi.cpp
+++ b/bdsg/cmake_bindings/bdsg/odgi.cpp
@@ -1,6 +1,8 @@
 #include <bdsg/odgi.hpp>
 #include <functional>
+#include <handlegraph/deletable_handle_graph.hpp>
 #include <handlegraph/handle_graph.hpp>
+#include <handlegraph/mutable_handle_graph.hpp>
 #include <handlegraph/types.hpp>
 #include <ios>
 #include <istream>
@@ -358,6 +360,19 @@ struct PyCallBack_bdsg_ODGI : public bdsg::ODGI {
 			else return pybind11::detail::cast_safe<bool>(std::move(o));
 		}
 		return ODGI::for_each_step_on_handle_impl(a0, a1);
+	}
+	unsigned long get_step_count(const struct handlegraph::handle_t & a0) const override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::ODGI *>(this), "get_step_count");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<unsigned long>::value) {
+				static pybind11::detail::overload_caster_t<unsigned long> caster;
+				return pybind11::detail::cast_ref<unsigned long>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<unsigned long>(std::move(o));
+		}
+		return ODGI::get_step_count(a0);
 	}
 	struct handlegraph::handle_t get_handle_of_step(const struct handlegraph::step_handle_t & a0) const override { 
 		pybind11::gil_scoped_acquire gil;
@@ -788,6 +803,32 @@ struct PyCallBack_bdsg_ODGI : public bdsg::ODGI {
 			else return pybind11::detail::cast_safe<std::string>(std::move(o));
 		}
 		return HandleGraph::get_subsequence(a0, a1, a2);
+	}
+	void increment_node_ids(long a0) override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::ODGI *>(this), "increment_node_ids");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<void>::value) {
+				static pybind11::detail::overload_caster_t<void> caster;
+				return pybind11::detail::cast_ref<void>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<void>(std::move(o));
+		}
+		return MutableHandleGraph::increment_node_ids(a0);
+	}
+	struct handlegraph::handle_t truncate_handle(const struct handlegraph::handle_t & a0, bool a1, unsigned long a2) override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::ODGI *>(this), "truncate_handle");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0, a1, a2);
+			if (pybind11::detail::cast_is_temporary_value_reference<struct handlegraph::handle_t>::value) {
+				static pybind11::detail::overload_caster_t<struct handlegraph::handle_t> caster;
+				return pybind11::detail::cast_ref<struct handlegraph::handle_t>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<struct handlegraph::handle_t>(std::move(o));
+		}
+		return DeletableHandleGraph::truncate_handle(a0, a1, a2);
 	}
 };
 

--- a/bdsg/cmake_bindings/bdsg/overlays/packed_path_position_overlay.cpp
+++ b/bdsg/cmake_bindings/bdsg/overlays/packed_path_position_overlay.cpp
@@ -486,6 +486,19 @@ struct PyCallBack_bdsg_PackedPositionOverlay : public bdsg::PackedPositionOverla
 		}
 		return PathPositionHandleGraph::for_each_step_position_on_handle(a0, a1);
 	}
+	unsigned long get_step_count(const struct handlegraph::handle_t & a0) const override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PackedPositionOverlay *>(this), "get_step_count");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<unsigned long>::value) {
+				static pybind11::detail::overload_caster_t<unsigned long> caster;
+				return pybind11::detail::cast_ref<unsigned long>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<unsigned long>(std::move(o));
+		}
+		return PathHandleGraph::get_step_count(a0);
+	}
 	bool for_each_path_handle_impl(const class std::function<bool (const struct handlegraph::path_handle_t &)> & a0) const override { 
 		pybind11::gil_scoped_acquire gil;
 		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PackedPositionOverlay *>(this), "for_each_path_handle_impl");
@@ -599,6 +612,8 @@ void bind_bdsg_overlays_packed_path_position_overlay(std::function< pybind11::mo
 		cl.def( pybind11::init<const class handlegraph::PathHandleGraph *>(), pybind11::arg("graph") );
 
 		cl.def( pybind11::init( [](){ return new bdsg::PackedPositionOverlay(); }, [](){ return new PyCallBack_bdsg_PackedPositionOverlay(); } ) );
+		cl.def( pybind11::init( [](PyCallBack_bdsg_PackedPositionOverlay const &o){ return new PyCallBack_bdsg_PackedPositionOverlay(o); } ) );
+		cl.def( pybind11::init( [](bdsg::PackedPositionOverlay const &o){ return new bdsg::PackedPositionOverlay(o); } ) );
 		cl.def("has_node", (bool (bdsg::PackedPositionOverlay::*)(long long) const) &bdsg::PackedPositionOverlay::has_node, "Method to check if a node exists by ID\n\nC++: bdsg::PackedPositionOverlay::has_node(long long) const --> bool", pybind11::arg("node_id"));
 		cl.def("get_handle", [](bdsg::PackedPositionOverlay const &o, const long long & a0) -> handlegraph::handle_t { return o.get_handle(a0); }, "", pybind11::arg("node_id"));
 		cl.def("get_handle", (struct handlegraph::handle_t (bdsg::PackedPositionOverlay::*)(const long long &, bool) const) &bdsg::PackedPositionOverlay::get_handle, "Look up the handle for the node with the given ID in the given orientation\n\nC++: bdsg::PackedPositionOverlay::get_handle(const long long &, bool) const --> struct handlegraph::handle_t", pybind11::arg("node_id"), pybind11::arg("is_reverse"));
@@ -634,24 +649,6 @@ void bind_bdsg_overlays_packed_path_position_overlay(std::function< pybind11::mo
 		cl.def("get_position_of_step", (unsigned long (bdsg::PackedPositionOverlay::*)(const struct handlegraph::step_handle_t &) const) &bdsg::PackedPositionOverlay::get_position_of_step, "Returns the position along the path of the beginning of this step measured in\n bases of sequence. In a circular path, positions start at the step returned by\n path_begin().\n\nC++: bdsg::PackedPositionOverlay::get_position_of_step(const struct handlegraph::step_handle_t &) const --> unsigned long", pybind11::arg("step"));
 		cl.def("get_step_at_position", (struct handlegraph::step_handle_t (bdsg::PackedPositionOverlay::*)(const struct handlegraph::path_handle_t &, const unsigned long &) const) &bdsg::PackedPositionOverlay::get_step_at_position, "Returns the step at this position, measured in bases of sequence starting at\n the step returned by path_begin(). If the position is past the end of the\n path, returns path_end().\n\nC++: bdsg::PackedPositionOverlay::get_step_at_position(const struct handlegraph::path_handle_t &, const unsigned long &) const --> struct handlegraph::step_handle_t", pybind11::arg("path"), pybind11::arg("position"));
 		cl.def("get_underlying_handle", (struct handlegraph::handle_t (bdsg::PackedPositionOverlay::*)(const struct handlegraph::handle_t &) const) &bdsg::PackedPositionOverlay::get_underlying_handle, "Returns the handle in the underlying graph that corresponds to a handle in the\n overlay\n\nC++: bdsg::PackedPositionOverlay::get_underlying_handle(const struct handlegraph::handle_t &) const --> struct handlegraph::handle_t", pybind11::arg("handle"));
-	}
-	{ // bdsg::BBHashHelper file:bdsg/overlays/packed_path_position_overlay.hpp line:257
-		pybind11::class_<bdsg::BBHashHelper, std::shared_ptr<bdsg::BBHashHelper>> cl(M("bdsg"), "BBHashHelper", "");
-		{ // bdsg::BBHashHelper::iterator file:bdsg/overlays/packed_path_position_overlay.hpp line:263
-			auto & enclosing_class = cl;
-			pybind11::class_<bdsg::BBHashHelper::iterator, std::shared_ptr<bdsg::BBHashHelper::iterator>> cl(enclosing_class, "iterator", "");
-			cl.def( pybind11::init( [](bdsg::BBHashHelper::iterator const &o){ return new bdsg::BBHashHelper::iterator(o); } ) );
-			cl.def("assign", (struct bdsg::BBHashHelper::iterator & (bdsg::BBHashHelper::iterator::*)(const struct bdsg::BBHashHelper::iterator &)) &bdsg::BBHashHelper::iterator::operator=, "C++: bdsg::BBHashHelper::iterator::operator=(const struct bdsg::BBHashHelper::iterator &) --> struct bdsg::BBHashHelper::iterator &", pybind11::return_value_policy::automatic, pybind11::arg("other"));
-			cl.def("plus_plus", (struct bdsg::BBHashHelper::iterator & (bdsg::BBHashHelper::iterator::*)()) &bdsg::BBHashHelper::iterator::operator++, "C++: bdsg::BBHashHelper::iterator::operator++() --> struct bdsg::BBHashHelper::iterator &", pybind11::return_value_policy::automatic);
-			cl.def("__mul__", (struct handlegraph::step_handle_t (bdsg::BBHashHelper::iterator::*)() const) &bdsg::BBHashHelper::iterator::operator*, "C++: bdsg::BBHashHelper::iterator::operator*() const --> struct handlegraph::step_handle_t");
-			cl.def("__eq__", (bool (bdsg::BBHashHelper::iterator::*)(const struct bdsg::BBHashHelper::iterator &) const) &bdsg::BBHashHelper::iterator::operator==, "C++: bdsg::BBHashHelper::iterator::operator==(const struct bdsg::BBHashHelper::iterator &) const --> bool", pybind11::arg("other"));
-			cl.def("__ne__", (bool (bdsg::BBHashHelper::iterator::*)(const struct bdsg::BBHashHelper::iterator &) const) &bdsg::BBHashHelper::iterator::operator!=, "C++: bdsg::BBHashHelper::iterator::operator!=(const struct bdsg::BBHashHelper::iterator &) const --> bool", pybind11::arg("other"));
-		}
-
-		cl.def( pybind11::init<const class handlegraph::PathHandleGraph *>(), pybind11::arg("graph") );
-
-		cl.def( pybind11::init( [](bdsg::BBHashHelper const &o){ return new bdsg::BBHashHelper(o); } ) );
-		cl.def("begin", (struct bdsg::BBHashHelper::iterator (bdsg::BBHashHelper::*)() const) &bdsg::BBHashHelper::begin, "C++ style range begin over steps\n\nC++: bdsg::BBHashHelper::begin() const --> struct bdsg::BBHashHelper::iterator");
-		cl.def("end", (struct bdsg::BBHashHelper::iterator (bdsg::BBHashHelper::*)() const) &bdsg::BBHashHelper::end, "C++ style range end over steps\n\nC++: bdsg::BBHashHelper::end() const --> struct bdsg::BBHashHelper::iterator");
+		cl.def("assign", (class bdsg::PackedPositionOverlay & (bdsg::PackedPositionOverlay::*)(const class bdsg::PackedPositionOverlay &)) &bdsg::PackedPositionOverlay::operator=, "C++: bdsg::PackedPositionOverlay::operator=(const class bdsg::PackedPositionOverlay &) --> class bdsg::PackedPositionOverlay &", pybind11::return_value_policy::automatic, pybind11::arg(""));
 	}
 }

--- a/bdsg/cmake_bindings/bdsg/overlays/packed_path_position_overlay_1.cpp
+++ b/bdsg/cmake_bindings/bdsg/overlays/packed_path_position_overlay_1.cpp
@@ -1,3 +1,4 @@
+#include <bdsg/overlays/packed_path_position_overlay.hpp>
 #include <bdsg/overlays/packed_subgraph_overlay.hpp>
 #include <bdsg/overlays/path_position_overlays.hpp>
 #include <functional>
@@ -741,6 +742,19 @@ struct PyCallBack_bdsg_PositionOverlay : public bdsg::PositionOverlay {
 		}
 		return PathPositionHandleGraph::for_each_step_position_on_handle(a0, a1);
 	}
+	unsigned long get_step_count(const struct handlegraph::handle_t & a0) const override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PositionOverlay *>(this), "get_step_count");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<unsigned long>::value) {
+				static pybind11::detail::overload_caster_t<unsigned long> caster;
+				return pybind11::detail::cast_ref<unsigned long>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<unsigned long>(std::move(o));
+		}
+		return PathHandleGraph::get_step_count(a0);
+	}
 	bool for_each_path_handle_impl(const class std::function<bool (const struct handlegraph::path_handle_t &)> & a0) const override { 
 		pybind11::gil_scoped_acquire gil;
 		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PositionOverlay *>(this), "for_each_path_handle_impl");
@@ -847,8 +861,27 @@ struct PyCallBack_bdsg_PositionOverlay : public bdsg::PositionOverlay {
 	}
 };
 
-void bind_bdsg_overlays_packed_subgraph_overlay(std::function< pybind11::module &(std::string const &namespace_) > &M)
+void bind_bdsg_overlays_packed_path_position_overlay_1(std::function< pybind11::module &(std::string const &namespace_) > &M)
 {
+	{ // bdsg::BBHashHelper file:bdsg/overlays/packed_path_position_overlay.hpp line:257
+		pybind11::class_<bdsg::BBHashHelper, std::shared_ptr<bdsg::BBHashHelper>> cl(M("bdsg"), "BBHashHelper", "");
+		{ // bdsg::BBHashHelper::iterator file:bdsg/overlays/packed_path_position_overlay.hpp line:263
+			auto & enclosing_class = cl;
+			pybind11::class_<bdsg::BBHashHelper::iterator, std::shared_ptr<bdsg::BBHashHelper::iterator>> cl(enclosing_class, "iterator", "");
+			cl.def( pybind11::init( [](bdsg::BBHashHelper::iterator const &o){ return new bdsg::BBHashHelper::iterator(o); } ) );
+			cl.def("assign", (struct bdsg::BBHashHelper::iterator & (bdsg::BBHashHelper::iterator::*)(const struct bdsg::BBHashHelper::iterator &)) &bdsg::BBHashHelper::iterator::operator=, "C++: bdsg::BBHashHelper::iterator::operator=(const struct bdsg::BBHashHelper::iterator &) --> struct bdsg::BBHashHelper::iterator &", pybind11::return_value_policy::automatic, pybind11::arg("other"));
+			cl.def("plus_plus", (struct bdsg::BBHashHelper::iterator & (bdsg::BBHashHelper::iterator::*)()) &bdsg::BBHashHelper::iterator::operator++, "C++: bdsg::BBHashHelper::iterator::operator++() --> struct bdsg::BBHashHelper::iterator &", pybind11::return_value_policy::automatic);
+			cl.def("__mul__", (struct handlegraph::step_handle_t (bdsg::BBHashHelper::iterator::*)() const) &bdsg::BBHashHelper::iterator::operator*, "C++: bdsg::BBHashHelper::iterator::operator*() const --> struct handlegraph::step_handle_t");
+			cl.def("__eq__", (bool (bdsg::BBHashHelper::iterator::*)(const struct bdsg::BBHashHelper::iterator &) const) &bdsg::BBHashHelper::iterator::operator==, "C++: bdsg::BBHashHelper::iterator::operator==(const struct bdsg::BBHashHelper::iterator &) const --> bool", pybind11::arg("other"));
+			cl.def("__ne__", (bool (bdsg::BBHashHelper::iterator::*)(const struct bdsg::BBHashHelper::iterator &) const) &bdsg::BBHashHelper::iterator::operator!=, "C++: bdsg::BBHashHelper::iterator::operator!=(const struct bdsg::BBHashHelper::iterator &) const --> bool", pybind11::arg("other"));
+		}
+
+		cl.def( pybind11::init<const class handlegraph::PathHandleGraph *>(), pybind11::arg("graph") );
+
+		cl.def( pybind11::init( [](bdsg::BBHashHelper const &o){ return new bdsg::BBHashHelper(o); } ) );
+		cl.def("begin", (struct bdsg::BBHashHelper::iterator (bdsg::BBHashHelper::*)() const) &bdsg::BBHashHelper::begin, "C++ style range begin over steps\n\nC++: bdsg::BBHashHelper::begin() const --> struct bdsg::BBHashHelper::iterator");
+		cl.def("end", (struct bdsg::BBHashHelper::iterator (bdsg::BBHashHelper::*)() const) &bdsg::BBHashHelper::end, "C++ style range end over steps\n\nC++: bdsg::BBHashHelper::end() const --> struct bdsg::BBHashHelper::iterator");
+	}
 	{ // bdsg::PackedSubgraphOverlay file:bdsg/overlays/packed_subgraph_overlay.hpp line:27
 		pybind11::class_<bdsg::PackedSubgraphOverlay, std::shared_ptr<bdsg::PackedSubgraphOverlay>, PyCallBack_bdsg_PackedSubgraphOverlay, handlegraph::ExpandingOverlayGraph> cl(M("bdsg"), "PackedSubgraphOverlay", "");
 		cl.def( pybind11::init<const class handlegraph::HandleGraph *>(), pybind11::arg("graph") );

--- a/bdsg/cmake_bindings/bdsg/overlays/path_position_overlays.cpp
+++ b/bdsg/cmake_bindings/bdsg/overlays/path_position_overlays.cpp
@@ -1,7 +1,9 @@
 #include <bdsg/overlays/path_position_overlays.hpp>
 #include <bdsg/overlays/strand_split_overlay.hpp>
 #include <functional>
+#include <handlegraph/deletable_handle_graph.hpp>
 #include <handlegraph/handle_graph.hpp>
+#include <handlegraph/mutable_handle_graph.hpp>
 #include <handlegraph/mutable_path_deletable_handle_graph.hpp>
 #include <handlegraph/path_handle_graph.hpp>
 #include <handlegraph/path_position_handle_graph.hpp>
@@ -737,6 +739,19 @@ struct PyCallBack_bdsg_MutablePositionOverlay : public bdsg::MutablePositionOver
 		}
 		return PathPositionHandleGraph::for_each_step_position_on_handle(a0, a1);
 	}
+	unsigned long get_step_count(const struct handlegraph::handle_t & a0) const override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::MutablePositionOverlay *>(this), "get_step_count");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<unsigned long>::value) {
+				static pybind11::detail::overload_caster_t<unsigned long> caster;
+				return pybind11::detail::cast_ref<unsigned long>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<unsigned long>(std::move(o));
+		}
+		return PathHandleGraph::get_step_count(a0);
+	}
 	bool for_each_path_handle_impl(const class std::function<bool (const struct handlegraph::path_handle_t &)> & a0) const override { 
 		pybind11::gil_scoped_acquire gil;
 		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::MutablePositionOverlay *>(this), "for_each_path_handle_impl");
@@ -840,6 +855,32 @@ struct PyCallBack_bdsg_MutablePositionOverlay : public bdsg::MutablePositionOver
 			else return pybind11::detail::cast_safe<bool>(std::move(o));
 		}
 		pybind11::pybind11_fail("Tried to call pure virtual function \"HandleGraph::for_each_handle_impl\"");
+	}
+	void increment_node_ids(long a0) override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::MutablePositionOverlay *>(this), "increment_node_ids");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<void>::value) {
+				static pybind11::detail::overload_caster_t<void> caster;
+				return pybind11::detail::cast_ref<void>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<void>(std::move(o));
+		}
+		return MutableHandleGraph::increment_node_ids(a0);
+	}
+	struct handlegraph::handle_t truncate_handle(const struct handlegraph::handle_t & a0, bool a1, unsigned long a2) override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::MutablePositionOverlay *>(this), "truncate_handle");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0, a1, a2);
+			if (pybind11::detail::cast_is_temporary_value_reference<struct handlegraph::handle_t>::value) {
+				static pybind11::detail::overload_caster_t<struct handlegraph::handle_t> caster;
+				return pybind11::detail::cast_ref<struct handlegraph::handle_t>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<struct handlegraph::handle_t>(std::move(o));
+		}
+		return DeletableHandleGraph::truncate_handle(a0, a1, a2);
 	}
 };
 

--- a/bdsg/cmake_bindings/bdsg/overlays/vectorizable_overlays.cpp
+++ b/bdsg/cmake_bindings/bdsg/overlays/vectorizable_overlays.cpp
@@ -973,6 +973,19 @@ struct PyCallBack_bdsg_PathVectorizableOverlay : public bdsg::PathVectorizableOv
 		}
 		pybind11::pybind11_fail("Tried to call pure virtual function \"HandleGraph::for_each_handle_impl\"");
 	}
+	unsigned long get_step_count(const struct handlegraph::handle_t & a0) const override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PathVectorizableOverlay *>(this), "get_step_count");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<unsigned long>::value) {
+				static pybind11::detail::overload_caster_t<unsigned long> caster;
+				return pybind11::detail::cast_ref<unsigned long>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<unsigned long>(std::move(o));
+		}
+		return PathHandleGraph::get_step_count(a0);
+	}
 	class std::vector<handlegraph::step_handle_t> steps_of_handle(const struct handlegraph::handle_t & a0, bool a1) const override { 
 		pybind11::gil_scoped_acquire gil;
 		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PathVectorizableOverlay *>(this), "steps_of_handle");

--- a/bdsg/cmake_bindings/bdsg/overlays/vectorizable_overlays_1.cpp
+++ b/bdsg/cmake_bindings/bdsg/overlays/vectorizable_overlays_1.cpp
@@ -1,7 +1,9 @@
 #include <bdsg/overlays/vectorizable_overlays.hpp>
 #include <bdsg/packed_graph.hpp>
 #include <functional>
+#include <handlegraph/deletable_handle_graph.hpp>
 #include <handlegraph/handle_graph.hpp>
+#include <handlegraph/mutable_handle_graph.hpp>
 #include <handlegraph/path_handle_graph.hpp>
 #include <handlegraph/path_position_handle_graph.hpp>
 #include <handlegraph/types.hpp>
@@ -660,6 +662,19 @@ struct PyCallBack_bdsg_PathPositionVectorizableOverlay : public bdsg::PathPositi
 			else return pybind11::detail::cast_safe<bool>(std::move(o));
 		}
 		pybind11::pybind11_fail("Tried to call pure virtual function \"HandleGraph::for_each_handle_impl\"");
+	}
+	unsigned long get_step_count(const struct handlegraph::handle_t & a0) const override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PathPositionVectorizableOverlay *>(this), "get_step_count");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<unsigned long>::value) {
+				static pybind11::detail::overload_caster_t<unsigned long> caster;
+				return pybind11::detail::cast_ref<unsigned long>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<unsigned long>(std::move(o));
+		}
+		return PathHandleGraph::get_step_count(a0);
 	}
 	class std::vector<handlegraph::step_handle_t> steps_of_handle(const struct handlegraph::handle_t & a0, bool a1) const override { 
 		pybind11::gil_scoped_acquire gil;
@@ -1409,6 +1424,19 @@ struct PyCallBack_bdsg_PackedGraph : public bdsg::PackedGraph {
 		}
 		return PackedGraph::get_magic_number();
 	}
+	unsigned long get_step_count(const struct handlegraph::handle_t & a0) const override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PackedGraph *>(this), "get_step_count");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<unsigned long>::value) {
+				static pybind11::detail::overload_caster_t<unsigned long> caster;
+				return pybind11::detail::cast_ref<unsigned long>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<unsigned long>(std::move(o));
+		}
+		return PathHandleGraph::get_step_count(a0);
+	}
 	class std::vector<handlegraph::step_handle_t> steps_of_handle(const struct handlegraph::handle_t & a0, bool a1) const override { 
 		pybind11::gil_scoped_acquire gil;
 		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PackedGraph *>(this), "steps_of_handle");
@@ -1461,6 +1489,32 @@ struct PyCallBack_bdsg_PackedGraph : public bdsg::PackedGraph {
 		}
 		return HandleGraph::has_edge(a0, a1);
 	}
+	void increment_node_ids(long a0) override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PackedGraph *>(this), "increment_node_ids");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<void>::value) {
+				static pybind11::detail::overload_caster_t<void> caster;
+				return pybind11::detail::cast_ref<void>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<void>(std::move(o));
+		}
+		return MutableHandleGraph::increment_node_ids(a0);
+	}
+	struct handlegraph::handle_t truncate_handle(const struct handlegraph::handle_t & a0, bool a1, unsigned long a2) override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PackedGraph *>(this), "truncate_handle");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0, a1, a2);
+			if (pybind11::detail::cast_is_temporary_value_reference<struct handlegraph::handle_t>::value) {
+				static pybind11::detail::overload_caster_t<struct handlegraph::handle_t> caster;
+				return pybind11::detail::cast_ref<struct handlegraph::handle_t>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<struct handlegraph::handle_t>(std::move(o));
+		}
+		return DeletableHandleGraph::truncate_handle(a0, a1, a2);
+	}
 };
 
 void bind_bdsg_overlays_vectorizable_overlays_1(std::function< pybind11::module &(std::string const &namespace_) > &M)
@@ -1477,6 +1531,8 @@ void bind_bdsg_overlays_vectorizable_overlays_1(std::function< pybind11::module 
 	{ // bdsg::PackedGraph file:bdsg/packed_graph.hpp line:44
 		pybind11::class_<bdsg::PackedGraph, std::shared_ptr<bdsg::PackedGraph>, PyCallBack_bdsg_PackedGraph, handlegraph::MutablePathDeletableHandleGraph, handlegraph::SerializableHandleGraph> cl(M("bdsg"), "PackedGraph", "PackedGraph is a HandleGraph implementation designed to use very little\n memory. It stores its data in bit-packed integer vectors, which are\n dynamically widened as needed in O(1) amortized time. Within these vectors,\n graphs are stored using adjacency linked lists.\n\n Since removals of elements can cause slots in the internal vectors to become\n unused, the graph will occasionally defragment itself after some\n modification operations, which involves copying its internal data\n structures.\n\n This implementation is a good choice when working with very large graphs,\n where the final memory usage of the constructed graph must be minimized. It\n is not a good choice when large fractions of the graph will need to be\n deleted and replaced; ODGI or HashGraph may be better for such workloads.");
 		cl.def( pybind11::init( [](){ return new bdsg::PackedGraph(); }, [](){ return new PyCallBack_bdsg_PackedGraph(); } ) );
+		cl.def( pybind11::init( [](PyCallBack_bdsg_PackedGraph const &o){ return new PyCallBack_bdsg_PackedGraph(o); } ) );
+		cl.def( pybind11::init( [](bdsg::PackedGraph const &o){ return new bdsg::PackedGraph(o); } ) );
 		cl.def("has_node", (bool (bdsg::PackedGraph::*)(long long) const) &bdsg::PackedGraph::has_node, "Method to check if a node exists by ID\n\nC++: bdsg::PackedGraph::has_node(long long) const --> bool", pybind11::arg("node_id"));
 		cl.def("get_handle", [](bdsg::PackedGraph const &o, const long long & a0) -> handlegraph::handle_t { return o.get_handle(a0); }, "", pybind11::arg("node_id"));
 		cl.def("get_handle", (struct handlegraph::handle_t (bdsg::PackedGraph::*)(const long long &, bool) const) &bdsg::PackedGraph::get_handle, "Look up the handle for the node with the given ID in the given orientation\n\nC++: bdsg::PackedGraph::get_handle(const long long &, bool) const --> struct handlegraph::handle_t", pybind11::arg("node_id"), pybind11::arg("is_reverse"));
@@ -1536,5 +1592,6 @@ void bind_bdsg_overlays_vectorizable_overlays_1(std::function< pybind11::module 
 		cl.def("increment_node_ids", (void (bdsg::PackedGraph::*)(long long)) &bdsg::PackedGraph::increment_node_ids, "Add the given value to all node IDs\n\nC++: bdsg::PackedGraph::increment_node_ids(long long) --> void", pybind11::arg("increment"));
 		cl.def("reassign_node_ids", (void (bdsg::PackedGraph::*)(const class std::function<long long (const long long &)> &)) &bdsg::PackedGraph::reassign_node_ids, "Reassign all node IDs as specified by the old->new mapping function.\n\nC++: bdsg::PackedGraph::reassign_node_ids(const class std::function<long long (const long long &)> &) --> void", pybind11::arg("get_new_id"));
 		cl.def("get_magic_number", (unsigned int (bdsg::PackedGraph::*)() const) &bdsg::PackedGraph::get_magic_number, "Returns a static high-entropy number to indicate the class\n\nC++: bdsg::PackedGraph::get_magic_number() const --> unsigned int");
+		cl.def("assign", (class bdsg::PackedGraph & (bdsg::PackedGraph::*)(const class bdsg::PackedGraph &)) &bdsg::PackedGraph::operator=, "C++: bdsg::PackedGraph::operator=(const class bdsg::PackedGraph &) --> class bdsg::PackedGraph &", pybind11::return_value_policy::automatic, pybind11::arg(""));
 	}
 }

--- a/bdsg/cmake_bindings/handlegraph/handle_graph.cpp
+++ b/bdsg/cmake_bindings/handlegraph/handle_graph.cpp
@@ -971,6 +971,19 @@ struct PyCallBack_handlegraph_PathHandleGraph : public handlegraph::PathHandleGr
 		}
 		pybind11::pybind11_fail("Tried to call pure virtual function \"PathHandleGraph::get_step_count\"");
 	}
+	unsigned long get_step_count(const struct handlegraph::handle_t & a0) const override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::PathHandleGraph *>(this), "get_step_count");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<unsigned long>::value) {
+				static pybind11::detail::overload_caster_t<unsigned long> caster;
+				return pybind11::detail::cast_ref<unsigned long>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<unsigned long>(std::move(o));
+		}
+		return PathHandleGraph::get_step_count(a0);
+	}
 	struct handlegraph::handle_t get_handle_of_step(const struct handlegraph::step_handle_t & a0) const override { 
 		pybind11::gil_scoped_acquire gil;
 		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::PathHandleGraph *>(this), "get_handle_of_step");
@@ -1455,6 +1468,7 @@ void bind_handlegraph_handle_graph(std::function< pybind11::module &(std::string
 		cl.def("get_path_name", (std::string (handlegraph::PathHandleGraph::*)(const struct handlegraph::path_handle_t &) const) &handlegraph::PathHandleGraph::get_path_name, "Look up the name of a path from a handle to it\n\nC++: handlegraph::PathHandleGraph::get_path_name(const struct handlegraph::path_handle_t &) const --> std::string", pybind11::arg("path_handle"));
 		cl.def("get_is_circular", (bool (handlegraph::PathHandleGraph::*)(const struct handlegraph::path_handle_t &) const) &handlegraph::PathHandleGraph::get_is_circular, "Look up whether a path is circular\n\nC++: handlegraph::PathHandleGraph::get_is_circular(const struct handlegraph::path_handle_t &) const --> bool", pybind11::arg("path_handle"));
 		cl.def("get_step_count", (unsigned long (handlegraph::PathHandleGraph::*)(const struct handlegraph::path_handle_t &) const) &handlegraph::PathHandleGraph::get_step_count, "Returns the number of node steps in the path\n\nC++: handlegraph::PathHandleGraph::get_step_count(const struct handlegraph::path_handle_t &) const --> unsigned long", pybind11::arg("path_handle"));
+		cl.def("get_step_count", (unsigned long (handlegraph::PathHandleGraph::*)(const struct handlegraph::handle_t &) const) &handlegraph::PathHandleGraph::get_step_count, "Returns the number of node steps on a handle\n\nC++: handlegraph::PathHandleGraph::get_step_count(const struct handlegraph::handle_t &) const --> unsigned long", pybind11::arg("handle"));
 		cl.def("get_handle_of_step", (struct handlegraph::handle_t (handlegraph::PathHandleGraph::*)(const struct handlegraph::step_handle_t &) const) &handlegraph::PathHandleGraph::get_handle_of_step, "Get a node handle (node ID and orientation) from a handle to an step on a path\n\nC++: handlegraph::PathHandleGraph::get_handle_of_step(const struct handlegraph::step_handle_t &) const --> struct handlegraph::handle_t", pybind11::arg("step_handle"));
 		cl.def("get_path_handle_of_step", (struct handlegraph::path_handle_t (handlegraph::PathHandleGraph::*)(const struct handlegraph::step_handle_t &) const) &handlegraph::PathHandleGraph::get_path_handle_of_step, "Returns a handle to the path that an step is on\n\nC++: handlegraph::PathHandleGraph::get_path_handle_of_step(const struct handlegraph::step_handle_t &) const --> struct handlegraph::path_handle_t", pybind11::arg("step_handle"));
 		cl.def("path_begin", (struct handlegraph::step_handle_t (handlegraph::PathHandleGraph::*)(const struct handlegraph::path_handle_t &) const) &handlegraph::PathHandleGraph::path_begin, "Get a handle to the first step, which will be an arbitrary step in a circular path\n that we consider \"first\" based on our construction of the path. If the path is empty,\n then the implementation must return the same value as path_end().\n\nC++: handlegraph::PathHandleGraph::path_begin(const struct handlegraph::path_handle_t &) const --> struct handlegraph::step_handle_t", pybind11::arg("path_handle"));

--- a/bdsg/cmake_bindings/handlegraph/mutable_path_mutable_handle_graph.cpp
+++ b/bdsg/cmake_bindings/handlegraph/mutable_path_mutable_handle_graph.cpp
@@ -192,6 +192,19 @@ struct PyCallBack_handlegraph_MutablePathMutableHandleGraph : public handlegraph
 		}
 		pybind11::pybind11_fail("Tried to call pure virtual function \"PathHandleGraph::get_step_count\"");
 	}
+	unsigned long get_step_count(const struct handlegraph::handle_t & a0) const override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::MutablePathMutableHandleGraph *>(this), "get_step_count");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<unsigned long>::value) {
+				static pybind11::detail::overload_caster_t<unsigned long> caster;
+				return pybind11::detail::cast_ref<unsigned long>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<unsigned long>(std::move(o));
+		}
+		return PathHandleGraph::get_step_count(a0);
+	}
 	struct handlegraph::handle_t get_handle_of_step(const struct handlegraph::step_handle_t & a0) const override { 
 		pybind11::gil_scoped_acquire gil;
 		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::MutablePathMutableHandleGraph *>(this), "get_handle_of_step");
@@ -725,6 +738,19 @@ struct PyCallBack_handlegraph_MutablePathMutableHandleGraph : public handlegraph
 		}
 		return MutableHandleGraph::increment_node_ids(a0);
 	}
+	void increment_node_ids(long a0) override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::MutablePathMutableHandleGraph *>(this), "increment_node_ids");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<void>::value) {
+				static pybind11::detail::overload_caster_t<void> caster;
+				return pybind11::detail::cast_ref<void>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<void>(std::move(o));
+		}
+		return MutableHandleGraph::increment_node_ids(a0);
+	}
 	void reassign_node_ids(const class std::function<long long (const long long &)> & a0) override { 
 		pybind11::gil_scoped_acquire gil;
 		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::MutablePathMutableHandleGraph *>(this), "reassign_node_ids");
@@ -769,6 +795,19 @@ struct PyCallBack_handlegraph_DeletableHandleGraph : public handlegraph::Deletab
 			else return pybind11::detail::cast_safe<void>(std::move(o));
 		}
 		pybind11::pybind11_fail("Tried to call pure virtual function \"DeletableHandleGraph::destroy_edge\"");
+	}
+	struct handlegraph::handle_t truncate_handle(const struct handlegraph::handle_t & a0, bool a1, unsigned long a2) override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::DeletableHandleGraph *>(this), "truncate_handle");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0, a1, a2);
+			if (pybind11::detail::cast_is_temporary_value_reference<struct handlegraph::handle_t>::value) {
+				static pybind11::detail::overload_caster_t<struct handlegraph::handle_t> caster;
+				return pybind11::detail::cast_ref<struct handlegraph::handle_t>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<struct handlegraph::handle_t>(std::move(o));
+		}
+		return DeletableHandleGraph::truncate_handle(a0, a1, a2);
 	}
 	void clear() override { 
 		pybind11::gil_scoped_acquire gil;
@@ -888,6 +927,19 @@ struct PyCallBack_handlegraph_DeletableHandleGraph : public handlegraph::Deletab
 		pybind11::pybind11_fail("Tried to call pure virtual function \"MutableHandleGraph::set_id_increment\"");
 	}
 	void increment_node_ids(long long a0) override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::DeletableHandleGraph *>(this), "increment_node_ids");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<void>::value) {
+				static pybind11::detail::overload_caster_t<void> caster;
+				return pybind11::detail::cast_ref<void>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<void>(std::move(o));
+		}
+		return MutableHandleGraph::increment_node_ids(a0);
+	}
+	void increment_node_ids(long a0) override { 
 		pybind11::gil_scoped_acquire gil;
 		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::DeletableHandleGraph *>(this), "increment_node_ids");
 		if (overload) {
@@ -1309,6 +1361,19 @@ struct PyCallBack_handlegraph_MutablePathDeletableHandleGraph : public handlegra
 			else return pybind11::detail::cast_safe<unsigned long>(std::move(o));
 		}
 		pybind11::pybind11_fail("Tried to call pure virtual function \"PathHandleGraph::get_step_count\"");
+	}
+	unsigned long get_step_count(const struct handlegraph::handle_t & a0) const override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::MutablePathDeletableHandleGraph *>(this), "get_step_count");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<unsigned long>::value) {
+				static pybind11::detail::overload_caster_t<unsigned long> caster;
+				return pybind11::detail::cast_ref<unsigned long>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<unsigned long>(std::move(o));
+		}
+		return PathHandleGraph::get_step_count(a0);
 	}
 	struct handlegraph::handle_t get_handle_of_step(const struct handlegraph::step_handle_t & a0) const override { 
 		pybind11::gil_scoped_acquire gil;
@@ -1843,6 +1908,19 @@ struct PyCallBack_handlegraph_MutablePathDeletableHandleGraph : public handlegra
 		}
 		return MutableHandleGraph::increment_node_ids(a0);
 	}
+	void increment_node_ids(long a0) override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::MutablePathDeletableHandleGraph *>(this), "increment_node_ids");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<void>::value) {
+				static pybind11::detail::overload_caster_t<void> caster;
+				return pybind11::detail::cast_ref<void>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<void>(std::move(o));
+		}
+		return MutableHandleGraph::increment_node_ids(a0);
+	}
 	void reassign_node_ids(const class std::function<long long (const long long &)> & a0) override { 
 		pybind11::gil_scoped_acquire gil;
 		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::MutablePathDeletableHandleGraph *>(this), "reassign_node_ids");
@@ -1882,6 +1960,19 @@ struct PyCallBack_handlegraph_MutablePathDeletableHandleGraph : public handlegra
 		}
 		pybind11::pybind11_fail("Tried to call pure virtual function \"DeletableHandleGraph::destroy_edge\"");
 	}
+	struct handlegraph::handle_t truncate_handle(const struct handlegraph::handle_t & a0, bool a1, unsigned long a2) override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::MutablePathDeletableHandleGraph *>(this), "truncate_handle");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0, a1, a2);
+			if (pybind11::detail::cast_is_temporary_value_reference<struct handlegraph::handle_t>::value) {
+				static pybind11::detail::overload_caster_t<struct handlegraph::handle_t> caster;
+				return pybind11::detail::cast_ref<struct handlegraph::handle_t>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<struct handlegraph::handle_t>(std::move(o));
+		}
+		return DeletableHandleGraph::truncate_handle(a0, a1, a2);
+	}
 	void clear() override { 
 		pybind11::gil_scoped_acquire gil;
 		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::MutablePathDeletableHandleGraph *>(this), "clear");
@@ -1911,6 +2002,7 @@ void bind_handlegraph_mutable_path_mutable_handle_graph(std::function< pybind11:
 		cl.def( pybind11::init( [](){ return new PyCallBack_handlegraph_DeletableHandleGraph(); } ) );
 		cl.def("destroy_handle", (void (handlegraph::DeletableHandleGraph::*)(const struct handlegraph::handle_t &)) &handlegraph::DeletableHandleGraph::destroy_handle, "Remove the node belonging to the given handle and all of its edges.\n Either destroys any paths in which the node participates, or leaves a\n \"hidden\", un-iterateable handle in the path to represent the sequence\n of the removed node.\n Invalidates the destroyed handle.\n May be called during serial for_each_handle iteration **ONLY** on the node being iterated.\n May **NOT** be called during parallel for_each_handle iteration.\n May **NOT** be called on the node from which edges are being followed during follow_edges.\n May **NOT** be called during iteration over paths, if it could destroy a path.\n May **NOT** be called during iteration along a path, if it could destroy that path.\n\nC++: handlegraph::DeletableHandleGraph::destroy_handle(const struct handlegraph::handle_t &) --> void", pybind11::arg("handle"));
 		cl.def("destroy_edge", (void (handlegraph::DeletableHandleGraph::*)(const struct handlegraph::handle_t &, const struct handlegraph::handle_t &)) &handlegraph::DeletableHandleGraph::destroy_edge, "Remove the edge connecting the given handles in the given order and orientations.\n Ignores nonexistent edges.\n Does not update any stored paths.\n\nC++: handlegraph::DeletableHandleGraph::destroy_edge(const struct handlegraph::handle_t &, const struct handlegraph::handle_t &) --> void", pybind11::arg("left"), pybind11::arg("right"));
+		cl.def("truncate_handle", (struct handlegraph::handle_t (handlegraph::DeletableHandleGraph::*)(const struct handlegraph::handle_t &, bool, unsigned long)) &handlegraph::DeletableHandleGraph::truncate_handle, "Shorten a node by truncating either the left or right side of the node, relative to the orientation\n of the handle, starting from a given offset along the nodes sequence. Any edges on the truncated\n end of the node are deleted. Returns a (possibly altered) handle to the truncated node.\n May invalid stored paths.\n\nC++: handlegraph::DeletableHandleGraph::truncate_handle(const struct handlegraph::handle_t &, bool, unsigned long) --> struct handlegraph::handle_t", pybind11::arg("handle"), pybind11::arg("trunc_left"), pybind11::arg("offset"));
 		cl.def("destroy_edge", (void (handlegraph::DeletableHandleGraph::*)(const struct std::pair<struct handlegraph::handle_t, struct handlegraph::handle_t> &)) &handlegraph::DeletableHandleGraph::destroy_edge, "Convenient wrapper for destroy_edge.\n\nC++: handlegraph::DeletableHandleGraph::destroy_edge(const struct std::pair<struct handlegraph::handle_t, struct handlegraph::handle_t> &) --> void", pybind11::arg("edge"));
 		cl.def("clear", (void (handlegraph::DeletableHandleGraph::*)()) &handlegraph::DeletableHandleGraph::clear, "Remove all nodes and edges. May also remove all paths, if applicable.\n\nC++: handlegraph::DeletableHandleGraph::clear() --> void");
 		cl.def("assign", (class handlegraph::DeletableHandleGraph & (handlegraph::DeletableHandleGraph::*)(const class handlegraph::DeletableHandleGraph &)) &handlegraph::DeletableHandleGraph::operator=, "C++: handlegraph::DeletableHandleGraph::operator=(const class handlegraph::DeletableHandleGraph &) --> class handlegraph::DeletableHandleGraph &", pybind11::return_value_policy::automatic, pybind11::arg(""));

--- a/bdsg/cmake_bindings/handlegraph/path_handle_graph.cpp
+++ b/bdsg/cmake_bindings/handlegraph/path_handle_graph.cpp
@@ -189,6 +189,19 @@ struct PyCallBack_handlegraph_MutablePathHandleGraph : public handlegraph::Mutab
 		}
 		pybind11::pybind11_fail("Tried to call pure virtual function \"PathHandleGraph::get_step_count\"");
 	}
+	unsigned long get_step_count(const struct handlegraph::handle_t & a0) const override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::MutablePathHandleGraph *>(this), "get_step_count");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<unsigned long>::value) {
+				static pybind11::detail::overload_caster_t<unsigned long> caster;
+				return pybind11::detail::cast_ref<unsigned long>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<unsigned long>(std::move(o));
+		}
+		return PathHandleGraph::get_step_count(a0);
+	}
 	struct handlegraph::handle_t get_handle_of_step(const struct handlegraph::step_handle_t & a0) const override { 
 		pybind11::gil_scoped_acquire gil;
 		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::MutablePathHandleGraph *>(this), "get_handle_of_step");
@@ -728,6 +741,19 @@ struct PyCallBack_handlegraph_MutableHandleGraph : public handlegraph::MutableHa
 		}
 		return MutableHandleGraph::increment_node_ids(a0);
 	}
+	void increment_node_ids(long a0) override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::MutableHandleGraph *>(this), "increment_node_ids");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<void>::value) {
+				static pybind11::detail::overload_caster_t<void> caster;
+				return pybind11::detail::cast_ref<void>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<void>(std::move(o));
+		}
+		return MutableHandleGraph::increment_node_ids(a0);
+	}
 	void reassign_node_ids(const class std::function<long long (const long long &)> & a0) override { 
 		pybind11::gil_scoped_acquire gil;
 		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::MutableHandleGraph *>(this), "reassign_node_ids");
@@ -979,9 +1005,9 @@ struct PyCallBack_handlegraph_MutableHandleGraph : public handlegraph::MutableHa
 
 void bind_handlegraph_path_handle_graph(std::function< pybind11::module &(std::string const &namespace_) > &M)
 {
-	{ // handlegraph::PathForEachSocket file:handlegraph/path_handle_graph.hpp line:200
+	{ // handlegraph::PathForEachSocket file:handlegraph/path_handle_graph.hpp line:203
 		pybind11::class_<handlegraph::PathForEachSocket, std::shared_ptr<handlegraph::PathForEachSocket>> cl(M("handlegraph"), "PathForEachSocket", "An auxilliary class that enables for each loops over paths. Not intended to\n constructed directly. Instead, use the PathHandleGraph's scan_path method.");
-		{ // handlegraph::PathForEachSocket::iterator file:handlegraph/path_handle_graph.hpp line:214
+		{ // handlegraph::PathForEachSocket::iterator file:handlegraph/path_handle_graph.hpp line:217
 			auto & enclosing_class = cl;
 			pybind11::class_<handlegraph::PathForEachSocket::iterator, std::shared_ptr<handlegraph::PathForEachSocket::iterator>> cl(enclosing_class, "iterator", "Iterator object over path");
 			cl.def( pybind11::init( [](handlegraph::PathForEachSocket::iterator const &o){ return new handlegraph::PathForEachSocket::iterator(o); } ) );
@@ -1026,6 +1052,7 @@ void bind_handlegraph_path_handle_graph(std::function< pybind11::module &(std::s
 		cl.def("apply_ordering", (void (handlegraph::MutableHandleGraph::*)(const class std::vector<handlegraph::handle_t> &, bool)) &handlegraph::MutableHandleGraph::apply_ordering, "Reorder the graph's internal structure to match that given.\n This sets the order that is used for iteration in functions like for_each_handle.\n Optionally may compact the id space of the graph to match the ordering, from 1->|ordering|.\n This may be a no-op in the case of graph implementations that do not have any mechanism to maintain an ordering.\n\nC++: handlegraph::MutableHandleGraph::apply_ordering(const class std::vector<handlegraph::handle_t> &, bool) --> void", pybind11::arg("order"), pybind11::arg("compact_ids"));
 		cl.def("set_id_increment", (void (handlegraph::MutableHandleGraph::*)(const long long &)) &handlegraph::MutableHandleGraph::set_id_increment, "Set a minimum id to increment the id space by, used as a hint during construction.\n May have no effect on a backing implementation.\n\nC++: handlegraph::MutableHandleGraph::set_id_increment(const long long &) --> void", pybind11::arg("min_id"));
 		cl.def("increment_node_ids", (void (handlegraph::MutableHandleGraph::*)(long long)) &handlegraph::MutableHandleGraph::increment_node_ids, "Add the given value to all node IDs.\n Has a default implementation in terms of reassign_node_ids, but can be\n implemented more efficiently in some graphs.\n\nC++: handlegraph::MutableHandleGraph::increment_node_ids(long long) --> void", pybind11::arg("increment"));
+		cl.def("increment_node_ids", (void (handlegraph::MutableHandleGraph::*)(long)) &handlegraph::MutableHandleGraph::increment_node_ids, "This specialization for long appears to be needed to avoid confusion about nid_t\n\nC++: handlegraph::MutableHandleGraph::increment_node_ids(long) --> void", pybind11::arg("increment"));
 		cl.def("reassign_node_ids", (void (handlegraph::MutableHandleGraph::*)(const class std::function<long long (const long long &)> &)) &handlegraph::MutableHandleGraph::reassign_node_ids, "Renumber all node IDs using the given function, which, given an old ID, returns the new ID.\n Modifies the graph in place. Invalidates all outstanding handles.\n If the graph supports paths, they also must be updated.\n The mapping function may return 0. In this case, the input ID will\n remain unchanged. The mapping function should not return any ID for\n which it would return 0.\n\nC++: handlegraph::MutableHandleGraph::reassign_node_ids(const class std::function<long long (const long long &)> &) --> void", pybind11::arg("get_new_id"));
 		cl.def("assign", (class handlegraph::MutableHandleGraph & (handlegraph::MutableHandleGraph::*)(const class handlegraph::MutableHandleGraph &)) &handlegraph::MutableHandleGraph::operator=, "C++: handlegraph::MutableHandleGraph::operator=(const class handlegraph::MutableHandleGraph &) --> class handlegraph::MutableHandleGraph &", pybind11::return_value_policy::automatic, pybind11::arg(""));
 	}

--- a/bdsg/cmake_bindings/handlegraph/path_position_handle_graph.cpp
+++ b/bdsg/cmake_bindings/handlegraph/path_position_handle_graph.cpp
@@ -161,6 +161,19 @@ struct PyCallBack_handlegraph_PathPositionHandleGraph : public handlegraph::Path
 		}
 		pybind11::pybind11_fail("Tried to call pure virtual function \"PathHandleGraph::get_step_count\"");
 	}
+	unsigned long get_step_count(const struct handlegraph::handle_t & a0) const override { 
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::PathPositionHandleGraph *>(this), "get_step_count");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<unsigned long>::value) {
+				static pybind11::detail::overload_caster_t<unsigned long> caster;
+				return pybind11::detail::cast_ref<unsigned long>(std::move(o), caster);
+			}
+			else return pybind11::detail::cast_safe<unsigned long>(std::move(o));
+		}
+		return PathHandleGraph::get_step_count(a0);
+	}
 	struct handlegraph::handle_t get_handle_of_step(const struct handlegraph::step_handle_t & a0) const override { 
 		pybind11::gil_scoped_acquire gil;
 		pybind11::function overload = pybind11::get_overload(static_cast<const handlegraph::PathPositionHandleGraph *>(this), "get_handle_of_step");

--- a/bdsg/include/bdsg/hash_graph.hpp
+++ b/bdsg/include/bdsg/hash_graph.hpp
@@ -142,6 +142,12 @@ public:
     /// Does not update any stored paths.
     void destroy_edge(const handle_t& left, const handle_t& right);
     
+    /// Shorten a node by truncating either the left or right side of the node, relative to the orientation
+    /// of the handle, starting from a given offset along the nodes sequence. Any edges on the truncated
+    /// end of the node are deleted. Returns a (possibly altered) handle to the truncated node.
+    /// May invalid stored paths.
+    handle_t truncate_handle(const handle_t& handle, bool trunc_left, size_t offset);
+    
     /// Remove all nodes and edges. Does not update any stored paths.
     void clear(void);
     

--- a/bdsg/src/hash_graph.cpp
+++ b/bdsg/src/hash_graph.cpp
@@ -262,7 +262,8 @@ namespace bdsg {
         
         // create edges between the segments of the original node
         for (size_t i = 1; i < return_val.size(); i++) {
-            create_edge(return_val[i - 1], return_val[i]);
+            graph[get_id(return_val[i - 1])].right_edges.push_back(return_val[i]);
+            graph[get_id(return_val[i])].left_edges.push_back(flip(return_val[i - 1]));
         }
         
         // update the paths and the occurrence records
@@ -370,6 +371,60 @@ namespace bdsg {
                 break;
             }
         }
+    }
+
+    handle_t HashGraph::truncate_handle(const handle_t& handle, bool trunc_left, size_t offset) {
+        
+        handle_t fwd_handle = forward(handle);
+        offset = get_is_reverse(handle) ? get_length(handle) - offset : offset;
+        trunc_left = get_is_reverse(handle) != trunc_left;
+        
+        node_t& node = graph[get_id(fwd_handle)];
+        // TODO: repetitive with destroy_edge
+        if (trunc_left) {
+            // remove references on the other nodes
+            for (handle_t left : node.left_edges) {
+                if (left == fwd_handle) {
+                    continue;
+                }
+                node_t& left_node = graph[get_id(left)];
+                auto& left_edge_list = get_is_reverse(left) ? left_node.left_edges : left_node.right_edges;
+                
+                for (handle_t& next : left_edge_list) {
+                    if (next == fwd_handle) {
+                        next = left_edge_list.back();
+                        left_edge_list.pop_back();
+                        break;
+                    }
+                }
+            }
+            // remove references on this node
+            node.left_edges.clear();
+            node.sequence = node.sequence.substr(offset, string::npos);
+        }
+        else {
+            // remove references on the other nodes
+            for (handle_t right : node.right_edges) {
+                if (right == flip(fwd_handle)) {
+                    continue;
+                }
+                node_t& right_node = graph[get_id(right)];
+                auto& right_edge_list = get_is_reverse(right) ? right_node.right_edges : right_node.left_edges;
+                
+                for (handle_t& prev : right_edge_list) {
+                    if (prev == flip(fwd_handle)) {
+                        prev = right_edge_list.back();
+                        right_edge_list.pop_back();
+                        break;
+                    }
+                }
+            }
+            // remove references on this node
+            node.right_edges.clear();
+            node.sequence.resize(offset);
+        }
+        
+        return handle;
     }
     
     void HashGraph::clear(void) {

--- a/bdsg/src/hash_graph.cpp
+++ b/bdsg/src/hash_graph.cpp
@@ -388,7 +388,7 @@ namespace bdsg {
                     continue;
                 }
                 node_t& left_node = graph[get_id(left)];
-                auto& left_edge_list = get_is_reverse(left) ? left_node.left_edges : left_node.right_edges;
+                auto& left_edge_list = get_is_reverse(left) ? left_node.right_edges : left_node.left_edges;
                 
                 for (handle_t& next : left_edge_list) {
                     if (next == fwd_handle) {

--- a/bdsg/src/test_libbdsg.cpp
+++ b/bdsg/src/test_libbdsg.cpp
@@ -1153,14 +1153,14 @@ void test_deletable_handle_graphs() {
             graph.create_edge(h6, h7);
             graph.create_edge(h7, h8);
             
-            graph.truncate_handle(h7, true, 1);
+            h7 = graph.truncate_handle(h7, true, 1);
             assert(graph.get_sequence(h7) == "CGG");
             assert(graph.get_degree(h7, true) == 0);
             assert(graph.get_degree(h7, false) == 1);
             assert(graph.get_degree(h6, false) == 0);
             assert(graph.get_degree(h8, true) == 1);
             
-            graph.truncate_handle(h7, false, 2);
+            h7 = graph.truncate_handle(h7, false, 2);
             assert(graph.get_sequence(h7) == "CG");
             assert(graph.get_degree(h7, true) == 0);
             assert(graph.get_degree(h7, false) == 0);

--- a/bdsg/src/test_libbdsg.cpp
+++ b/bdsg/src/test_libbdsg.cpp
@@ -1145,6 +1145,27 @@ void test_deletable_handle_graphs() {
                 assert(found4);
                 assert(found5);
             }
+            
+            auto h6 = graph.create_handle("ACGT");
+            auto h7 = graph.create_handle("GCGG");
+            auto h8 = graph.create_handle("TTCA");
+            
+            graph.create_edge(h6, h7);
+            graph.create_edge(h7, h8);
+            
+            graph.truncate_handle(h7, true, 1);
+            assert(graph.get_sequence(h7) == "CGG");
+            assert(graph.get_degree(h7, true) == 0);
+            assert(graph.get_degree(h7, false) == 1);
+            assert(graph.get_degree(h6, false) == 0);
+            assert(graph.get_degree(h8, true) == 1);
+            
+            graph.truncate_handle(h7, false, 2);
+            assert(graph.get_sequence(h7) == "CG");
+            assert(graph.get_degree(h7, true) == 0);
+            assert(graph.get_degree(h7, false) == 0);
+            assert(graph.get_degree(h6, false) == 0);
+            assert(graph.get_degree(h8, true) == 0);
         }
     }
     


### PR DESCRIPTION
I implemented a faster method to truncate a node sequence in HashGraph, which is an operation I use for mpmap. The previous implementation was based on `divide_handle`. The bindings have been updated to reflect the extension of the libhandlegraph interface.