### PR TITLE
Switch to the vgteam fork of SDSL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/sdsl-lite"]
 	path = bdsg/deps/sdsl-lite
-	url = https://github.com/simongog/sdsl-lite.git
+	url = https://github.com/vgteam/sdsl-lite.git
 [submodule "deps/DYNAMIC"]
 	path = bdsg/deps/DYNAMIC
 	url = https://github.com/vgteam/DYNAMIC.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - cd .. 
   - rm -Rf build
 dist: bionic
-osx_image: xcode10.1
+osx_image: xcode12.2
   
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # Control file for continuous integration testing at http://travis-ci.org/
 
 language: cpp
-compiler: gcc
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libomp doxygen; fi
@@ -18,14 +17,14 @@ script:
   - make clean
   - cd .. 
   - rm -Rf build
-dist: bionic
-osx_image: xcode12.2
   
-matrix:
+jobs:
   include:
     - os: linux
+      dist: bionic
       compiler: gcc
     - os: osx
+      osx_image: xcode12.2
       compiler: clang
       
 addons:


### PR DESCRIPTION
Switch to the [vgteam fork](https://github.com/vgteam/sdsl-lite) of SDSL. The fork will be maintained at least until [SDSL 3.0](https://github.com/xxsds/sdsl-lite) is released and we are ready to start using it.