### PR TITLE
Fix HashGraph moving and copying

### DIFF
--- a/bdsg/include/bdsg/hash_graph.hpp
+++ b/bdsg/include/bdsg/hash_graph.hpp
@@ -446,6 +446,13 @@ private:
     
     /// Replace the ID in a handle with a different number
     static handle_t set_id(const handle_t& internal, nid_t new_id);
+    
+public:
+    /// Move/copy constructors/assignment operators
+    HashGraph(const HashGraph& other);
+    HashGraph& operator=(const HashGraph& other);
+    HashGraph(HashGraph&& other);
+    HashGraph& operator=(HashGraph&& other);
 };
     
     

--- a/bdsg/src/hash_graph.cpp
+++ b/bdsg/src/hash_graph.cpp
@@ -18,6 +18,56 @@ namespace bdsg {
     HashGraph::~HashGraph() {
         
     }
+
+    HashGraph::HashGraph(const HashGraph& other) {
+        *this = other;
+    }
+
+    HashGraph::HashGraph(HashGraph&& other) {
+        *this = move(other);
+    }
+
+    HashGraph& HashGraph::operator=(const HashGraph& other) {
+        
+        max_id = other.max_id;
+        min_id = other.min_id;
+        path_id = other.path_id;
+        paths = other.paths;
+        next_path_id = other.next_path_id;
+        
+        // can't directly copy the nodes, because their pointers to path mappings
+        // will be different in the copy
+        graph.reserve(other.graph.size());
+        for (const auto& node_rec : other.graph) {
+            
+            graph[node_rec.first] = node_t(node_rec.second.sequence);
+            
+            node_t& node = graph[node_rec.first];
+            node.left_edges = node_rec.second.left_edges;
+            node.right_edges = node_rec.second.right_edges;
+            
+            node.occurrences.reserve(node_rec.second.occurrences.size());
+        }
+        
+        // and rebuild the occurrence index for the new pointers
+        for_each_path_handle_impl([&](const path_handle_t& path) {
+            for_each_step_in_path(path, [&](const step_handle_t& step) {
+                path_mapping_t* mapping = (path_mapping_t*) intptr_t(as_integers(step)[1]);
+                graph[get_id(mapping->handle)].occurrences.push_back(mapping);
+            });
+        });
+        return *this;
+    }
+
+    HashGraph& HashGraph::operator=(HashGraph&& other) {
+        max_id = other.max_id;
+        min_id = other.min_id;
+        graph = move(other.graph);
+        path_id = move(other.path_id);
+        paths = move(other.paths);
+        next_path_id = other.next_path_id;
+        return *this;
+    }
     
     HashGraph::HashGraph(istream& in) {
         deserialize(in);

--- a/bdsg/src/hash_graph.cpp
+++ b/bdsg/src/hash_graph.cpp
@@ -55,6 +55,7 @@ namespace bdsg {
                 path_mapping_t* mapping = (path_mapping_t*) intptr_t(as_integers(step)[1]);
                 graph[get_id(mapping->handle)].occurrences.push_back(mapping);
             });
+            return true;
         });
         return *this;
     }

--- a/bdsg/src/test_libbdsg.cpp
+++ b/bdsg/src/test_libbdsg.cpp
@@ -17,6 +17,7 @@
 #include <stdexcept>
 
 #include <sys/stat.h>
+#include <handlegraph/algorithms/are_equivalent.hpp>
 
 #include "bdsg/odgi.hpp"
 #include "bdsg/packed_graph.hpp"
@@ -4097,6 +4098,51 @@ void test_mapped_packed_graph() {
     cerr << "MappedPackedGraph tests successful!" << endl;
 }
 
+void test_hash_graph() {
+    
+    // make sure the copy and moves work as expected
+    
+    HashGraph g;
+    
+    handle_t h1 = g.create_handle("A");
+    handle_t h2 = g.create_handle("T");
+    handle_t h3 = g.create_handle("G");
+    
+    g.create_edge(h1, h2);
+    g.create_edge(h2, h3);
+    
+    path_handle_t p = g.create_path_handle("p");
+    g.append_step(p, h1);
+    g.append_step(p, h2);
+    g.append_step(p, h3);
+    
+    HashGraph g_copy_1 = g;
+    HashGraph g_copy_2(g);
+    HashGraph g_copy_3(g);
+    HashGraph g_copy_4(g);
+    
+    HashGraph g_move_1 = move(g_copy_3);
+    HashGraph g_move_2(move(g_copy_3));
+    
+    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_copy_1));
+    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_copy_2));
+    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_move_1));
+    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_move_2));
+    
+    // delete a handle on a path to trigger the occurrence index to be accessed
+    g_copy_1.destroy_handle(g_copy_1.get_handle(g.get_id(h2)));
+    g_copy_2.destroy_handle(g_copy_2.get_handle(g.get_id(h2)));
+    g_move_1.destroy_handle(g_move_1.get_handle(g.get_id(h2)));
+    g_move_2.destroy_handle(g_move_2.get_handle(g.get_id(h2)));
+    g.destroy_handle(h2);
+    
+    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_copy_1));
+    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_copy_2));
+    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_move_1));
+    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_move_2));
+    
+    cerr << "HashGraph tests successful!" << endl;
+}
 
 int main(void) {
     test_mmap_backend();
@@ -4121,4 +4167,5 @@ int main(void) {
     test_vectorizable_overlays();
     test_packed_subgraph_overlay();
     test_mapped_packed_graph();
+    test_hash_graph();
 }

--- a/bdsg/src/test_libbdsg.cpp
+++ b/bdsg/src/test_libbdsg.cpp
@@ -4122,12 +4122,12 @@ void test_hash_graph() {
     HashGraph g_copy_4(g);
     
     HashGraph g_move_1 = move(g_copy_3);
-    HashGraph g_move_2(move(g_copy_3));
+    HashGraph g_move_2(move(g_copy_4));
     
-    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_copy_1));
-    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_copy_2));
-    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_move_1));
-    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_move_2));
+    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_copy_1, true));
+    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_copy_2, true));
+    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_move_1, true));
+    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_move_2, true));
     
     // delete a handle on a path to trigger the occurrence index to be accessed
     g_copy_1.destroy_handle(g_copy_1.get_handle(g.get_id(h2)));
@@ -4136,10 +4136,10 @@ void test_hash_graph() {
     g_move_2.destroy_handle(g_move_2.get_handle(g.get_id(h2)));
     g.destroy_handle(h2);
     
-    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_copy_1));
-    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_copy_2));
-    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_move_1));
-    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_move_2));
+    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_copy_1, true));
+    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_copy_2, true));
+    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_move_1, true));
+    assert(handlegraph::algorithms::are_equivalent_with_paths(&g, &g_move_2, true));
     
     cerr << "HashGraph tests successful!" << endl;
 }


### PR DESCRIPTION
I turned up some bugs in `HashGraph`'s copying, which basically boiled down to copying addresses of variables in the copied graph.