### PR TITLE
Fix MacOS empty CMAKE_INSTALL_LIBDIR when using CMAKE_INSTALL_PREFIX variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,10 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   # Mac needs libdl and libomp when linking the library and a hint on where to look for them
   # Mac doesn't have $ORIGIN for RPaths. We might not be able to produce a working Mac wheel for Python bindings.
   set(PLATFORM_EXTRA_LIB_FLAGS -ldl -lomp -L/opt/local/lib/libomp -L/usr/local/lib)
-  
+
+  message(STATUS "CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}")
+  message(STATUS "CMAKE_INSTALL_LIBDIR: ${CMAKE_INSTALL_LIBDIR}")
+
   # Mac needs install names set after installation
   SET(CMAKE_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,10 +54,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   # Mac needs libdl and libomp when linking the library and a hint on where to look for them
   # Mac doesn't have $ORIGIN for RPaths. We might not be able to produce a working Mac wheel for Python bindings.
   set(PLATFORM_EXTRA_LIB_FLAGS -ldl -lomp -L/opt/local/lib/libomp -L/usr/local/lib)
-
-  message(STATUS "CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}")
-  message(STATUS "CMAKE_INSTALL_LIBDIR: ${CMAKE_INSTALL_LIBDIR}")
-
+  
   # Mac needs install names set after installation
   SET(CMAKE_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ set(CMAKE_CXX_STANDARD 14)
 # linker options.
 set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
 
+# And GNU ideas of install directories
+include(GNUInstallDirs)
+
 # Use all standard-compliant optimizations
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -g")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -g")
@@ -85,8 +88,6 @@ include_directories("${PROJECT_SOURCE_DIR}")
 
 # Add external projects
 include(ExternalProject)
-# And GNU ideas of install directories
-include(GNUInstallDirs)
 
 # sdsl-lite (gives an "sdsl" target)
 set(BUILD_SHARED_LIBS ON CACHE BOOL "Build sdsl-lite shared libraries")


### PR DESCRIPTION
This fixes the issue where linking libbdsg doesn't work on MacOS because the dylibs have the wrong path for their `INSTALL_NAME_DIR` or `LC_ID_DYLIB`. 