### PR TITLE
Trim unused memory and add memory reporting

### DIFF
--- a/bdsg/include/bdsg/internal/mapped_structs.hpp
+++ b/bdsg/include/bdsg/internal/mapped_structs.hpp
@@ -307,10 +307,17 @@ public:
     static void* find_first_allocation(chainid_t chain, size_t bytes);
     
     /**
-     * Get the fraction of bytes in the chain which are free, or NaN if the
-     * chain is empty or not a chain.
+     * Return the total number of bytes in the given chain.
      */
-    static float get_portion_free(chainid_t chain);
+    static size_t get_chain_size(chainid_t chain);
+    
+    /**
+     * Get statistics about the memory in a chain. Returns all 0s if not a managed chain.
+     *
+     * Returns the total bytes in the chain, the number of allocateable bytes,
+     * and the number of bytes reclaimable when the chain is closed. 
+     */
+    static std::tuple<size_t, size_t, size_t> get_usage(chainid_t chain);
     
     /**
      * Scan all memory regions in the given chain. Calls the iteratee with each
@@ -482,7 +489,7 @@ protected:
                                       const std::function<void(AllocatorHeader*)>& callback);
                                       
     /**
-     * While a final free block exists, drop it from the freee list.
+     * While a final free block exists, drop it from the free list.
      * Return the total number of bytes after the last allocated block.
      *
      * Note that you should not map anything after calling this function! You
@@ -684,6 +691,14 @@ public:
      * Free any associated memory and become empty.
      */
     void reset();
+    
+    /*
+     * Get statistics about the pointer's associated memory chain.
+     *
+     * Returns the total bytes, the number of allocateable bytes,
+     * and the number of bytes reclaimable when closed as a mapped file. 
+     */
+    std::tuple<size_t, size_t, size_t> get_usage();
 private:
     Manager::chainid_t chain = Manager::NO_CHAIN;
 };
@@ -1399,8 +1414,6 @@ void CompatVector<T, Alloc>::resize(size_t new_size) {
         reserve(std::max(new_size, size() * RESIZE_FACTOR));
     }
    
-    // TODO: throw away excess memory when shrinking
-   
     if (new_size < size()) {
         // We shrank, and we had at least one item.
 #ifdef debug_compat_vector
@@ -1429,7 +1442,50 @@ void CompatVector<T, Alloc>::resize(size_t new_size) {
 
 template<typename T, typename Alloc>
 void CompatVector<T, Alloc>::shrink_to_fit() {
-    // TODO: actually reallocate smaller.
+    // Actually reallocate smaller.
+    if (length == reserved_length) {
+        // Nothing to do!
+        return;
+    }
+    
+    // TODO: unify some code with reserve()?
+    
+    // Find where the data is. This can't be null since we have a
+    // reserved_length > length (since it isn't equal and can never be less).
+    T* old_first = first;
+    // And how much there is
+    size_t old_reserved_length = reserved_length;
+    
+#ifdef debug_compat_vector
+    std::cerr << "Shrinking vector at " << (intptr_t)this
+        << " with " << old_reserved_length << " spaces at "
+        << (intptr_t) old_first << " to have " << length  << " spaces" << std::endl;
+#endif
+    
+    // Allocate space for the new data, and get the position in the context
+    T* new_first  = alloc.allocate(length);
+    
+    // Record the new reserved length
+    reserved_length = length;
+    
+#ifdef debug_compat_vector
+    std::cerr << "Vector data moving from " << (intptr_t) old_first
+        << " to " << (intptr_t) new_first << std::endl;
+#endif
+    for (size_t i = 0; i < size(); i++) {
+        // Move over the preserved values.
+        new (new_first + i) T(std::move(*(old_first + i)));
+    }
+    
+    for (size_t i = 0; i < size(); i++) {
+        // Destroy all the original values
+        (old_first + i)->~T();
+    }
+    
+    // Free old memory
+    alloc.deallocate(old_first, old_reserved_length);
+    
+    first = new_first;
 }
 
 template<typename T, typename Alloc>
@@ -2136,6 +2192,11 @@ void UniqueMappedPointer<T>::reset() {
         Manager::destroy_chain(chain);
         chain = Manager::NO_CHAIN;
     }
+}
+
+template<typename T>
+std::tuple<size_t, size_t, size_t> UniqueMappedPointer<T>::get_usage() {
+    return Manager::get_usage(chain);
 }
 
 }

--- a/bdsg/include/bdsg/internal/mapped_structs.hpp
+++ b/bdsg/include/bdsg/internal/mapped_structs.hpp
@@ -314,8 +314,8 @@ public:
     /**
      * Get statistics about the memory in a chain. Returns all 0s if not a managed chain.
      *
-     * Returns the total bytes in the chain, the number of allocateable bytes,
-     * and the number of bytes reclaimable when the chain is closed. 
+     * Returns the total bytes in the chain, the number of free bytes,
+     * and the number of free bytes reclaimable when the chain is closed. 
      */
     static std::tuple<size_t, size_t, size_t> get_usage(chainid_t chain);
     
@@ -695,8 +695,8 @@ public:
     /*
      * Get statistics about the pointer's associated memory chain.
      *
-     * Returns the total bytes, the number of allocateable bytes,
-     * and the number of bytes reclaimable when closed as a mapped file. 
+     * Returns the total bytes, the number of free bytes, and the number of
+     * free bytes reclaimable when closed as a mapped file. 
      */
     std::tuple<size_t, size_t, size_t> get_usage();
 private:

--- a/bdsg/include/bdsg/internal/packed_structs.hpp
+++ b/bdsg/include/bdsg/internal/packed_structs.hpp
@@ -102,6 +102,9 @@ public:
     /// If necessary, expand capacity so that the given number of entries can
     /// be included in the vector without reallocating. Never shrinks capacity.
     inline void reserve(const size_t& future_size);
+    
+    /// Reallocate smaller after having been resized down.
+    inline void shrink_to_fit();
         
     /// Returns the number of values.
     inline size_t size() const;
@@ -195,6 +198,9 @@ public:
     /// be included in the vector without reallocating. Never shrinks capacity.
     inline void reserve(const size_t& future_size);
     
+    /// Reallocate smaller after having been resized down.
+    inline void shrink_to_fit();
+    
     /// Returns the number of values
     inline size_t size() const;
     
@@ -282,6 +288,9 @@ public:
     /// If necessary, expand capacity so that the given number of entries can
     /// be included in the vector without reallocating. Never shrinks capacity.
     inline void reserve(const size_t& future_size);
+    
+    /// Reallocate smaller after having been resized down.
+    inline void shrink_to_fit();
     
     /// Returns the number of values
     inline size_t size() const;
@@ -617,6 +626,11 @@ inline void PackedVector<Backend>::reserve(const size_t& future_size) {
     if (future_size > vec.size()) {
         repack(vec, vec.width(), future_size);
     }
+}
+
+template<typename Backend>
+inline void PackedVector<Backend>::shrink_to_fit() {
+    vec.shrink_to_fit();
 }
 
 template<typename Backend>
@@ -997,6 +1011,12 @@ inline void PagedVector<page_size, Backend>::reserve(const size_t& future_size) 
 }
 
 template<size_t page_size, typename Backend>
+inline void PagedVector<page_size, Backend>::shrink_to_fit() {
+    anchors.shrink_to_fit();
+    pages.shrink_to_fit();
+}
+
+template<size_t page_size, typename Backend>
 inline size_t PagedVector<page_size, Backend>::size() const {
     return filled;
 }
@@ -1153,6 +1173,12 @@ inline void RobustPagedVector<page_size, Backend>::reserve(const size_t& future_
     else {
         first_page.reserve(future_size);
     }
+}
+
+template<size_t page_size, typename Backend>
+inline void RobustPagedVector<page_size, Backend>::shrink_to_fit() {
+    first_page.shrink_to_fit();
+    latter_pages.shrink_to_fit();
 }
 
 template<size_t page_size, typename Backend>

--- a/bdsg/src/mapped_structs.cpp
+++ b/bdsg/src/mapped_structs.cpp
@@ -789,6 +789,71 @@ void* Manager::find_first_allocation(chainid_t chain, size_t bytes) {
     return first_allocated;
 }
 
+size_t Manager::get_chain_size(chainid_t chain) {
+    if (chain == NO_CHAIN) {
+        return 0;
+    }
+
+    LinkRecord* first;
+    
+    {
+        // Get read access to manager data structures
+        std::shared_lock<std::shared_timed_mutex> lock(Manager::mutex);
+        
+        // Find the first link
+        first = &address_space_index.at((intptr_t) chain);
+    }
+    
+    // The size is recorded here
+    return first->total_size;
+
+}
+
+std::tuple<size_t, size_t, size_t> Manager::get_usage(chainid_t chain) {
+    if (chain == NO_CHAIN) {
+        return std::make_tuple<size_t, size_t, size_t>(0, 0, 0);
+    }
+    
+    // We need the total chain length so we can tell if the last
+    // chain-contiguous run of free blocks abuts the end of the chain.
+    size_t total_length = get_chain_size(chain);
+    
+    // How many bytes of free payload have we seen?
+    size_t free_payload_bytes = 0;
+    
+    // How many free bytes are at the end?
+    size_t reclaimable = 0;
+    
+    with_allocator_header(chain, [&](AllocatorHeader* header) {
+        AllocatorBlock* free_block = header->last_free;
+        while (free_block) {
+            // The block has some free payload
+            free_payload_bytes += free_block->size;
+            
+            // Where in the chain does it end?
+            size_t block_end = get_chain_and_position(free_block).second +
+                free_block->size + sizeof(AllocatorBlock);
+            
+            if (block_end == total_length - reclaimable) {
+                // This abuts the existing trailing reclaimable space, so
+                // expand it over this block.
+                reclaimable += free_block->size + sizeof(AllocatorBlock);
+            }
+            
+            // Go left to the previous free block in the chain, if any.
+            free_block = free_block->prev;
+        }
+    });
+
+#ifdef debug_manager
+    std::cerr << "Memory usage: " << total_length << " total, "
+        << free_payload_bytes << " free, "
+        << reclaimable << " reclaimable" << endl;
+#endif
+    
+    return std::make_tuple(total_length, free_payload_bytes, reclaimable);
+}
+
 void Manager::scan_chain(chainid_t chain, const std::function<void(const void*, size_t)>& iteratee) {
     // Start a cursor in the chain
     size_t chain_offset = 0;
@@ -858,60 +923,56 @@ size_t Manager::reclaim_tail(chainid_t chain) {
         return 0;
     }
     
-    LinkRecord* first;
-    
-    {
-        // Get read access to manager data structures
-        std::shared_lock<std::shared_timed_mutex> lock(Manager::mutex);
-        
-        // Find the first link
-        first = &address_space_index.at((intptr_t) chain);
-    }
+    // Get the past-end position in the chain, and use that as our cursor to walk backward.
+    size_t first_unused_byte = get_chain_size(chain);
     
     // Track how many bytes we removed
     size_t reclaimed_bytes = 0;
     
-    // Find the header
-    AllocatorHeader* header = (AllocatorHeader*)(((char*) chain) + first->prefix_size);
-    
-    {
-        // Get exclusive access to the allocator
-        std::unique_lock<std::mutex> lock(*(first->allocator_mutex));
-        
-        // Get the past-end position in the chain, and use that as our cursor to walk backward.
-        assert(first->total_size > 0);
-        size_t first_unused_byte = first->total_size;
-    
+    with_allocator_header(chain, [&](AllocatorHeader* header) {
         while (header->last_free) {
             // For each free block, end to start
-            size_t total_block_size = header->last_free->size + sizeof(AllocatorBlock);
+            AllocatorBlock* last_free = header->last_free;
+            size_t total_block_size = last_free->size + sizeof(AllocatorBlock);
             
             // Get its past-end position in the chain
-            size_t past_block_end = get_chain_and_position(header->last_free).second + total_block_size;
+            size_t past_block_end = get_chain_and_position(last_free).second + total_block_size;
                 
             if (first_unused_byte == past_block_end) {
                 // We can pop off this block
                 
 #ifdef debug_manager
-                std::cerr << "Reclaiming trailing free block " << header->last_free << std::endl;
+                std::cerr << "Reclaiming trailing free block " << last_free << std::endl;
 #endif
                 
+                // Record reclaiming these bytes
                 reclaimed_bytes += total_block_size;
-                past_block_end -= total_block_size;
-                header->last_free->detach();
+                // Bring the cursor back to before the block we reclaimed.
+                first_unused_byte -= total_block_size;
+                
+                // Remove the block from the free list. We have to update the
+                // header pointers ourselves.
+                auto connected = last_free->detach();
+                header->last_free = connected.first;
+                if (header->first_free == last_free) {
+                    // This was the first free block.
+                    // The first free block is now the right neighbor, if any.
+                    header->first_free = connected.second;
+                }
+                
                 // Now last_free has moved, so check that block, if it exists.
             } else {
                 // We've reached a block we can't reclaim. We have to stop the scan.
                 
 #ifdef debug_manager
-                std::cerr << "Last free block ends at " << first_unused_byte
-                    << " and not " << past_block_end << std::endl;
+                std::cerr << "Last free block ends at " << past_block_end
+                    << " and not " << first_unused_byte << std::endl;
 #endif
                 
                 break;
             }
         }
-    }
+    });
     
 #ifdef debug_manager
     std::cerr << "Reclaimed " << reclaimed_bytes << " bytes at end of chain " << chain << std::endl;

--- a/bdsg/src/mapped_structs.cpp
+++ b/bdsg/src/mapped_structs.cpp
@@ -884,7 +884,7 @@ size_t Manager::reclaim_tail(chainid_t chain) {
     
         while (header->last_free) {
             // For each free block, end to start
-            size_t total_block_size = header->last_free->size() + sizeof(AllocatorBlock);
+            size_t total_block_size = header->last_free->size + sizeof(AllocatorBlock);
             
             // Get its past-end position in the chain
             size_t past_block_end = get_chain_and_position(header->last_free).second + total_block_size;

--- a/bdsg/src/test_libbdsg.cpp
+++ b/bdsg/src/test_libbdsg.cpp
@@ -527,12 +527,13 @@ void test_mapped_structs() {
         std::tuple<size_t, size_t, size_t> total_free_reclaimable = numbers_holder.get_usage();
         // Total bytes must be no less than free bytes
         assert(get<0>(total_free_reclaimable) >= get<1>(total_free_reclaimable));
-        // Total bytes must be no less than reclaimable bytes
-        assert(get<0>(total_free_reclaimable) >= get<2>(total_free_reclaimable));
+        // Free bytes must be no less than reclaimable bytes
+        assert(get<1>(total_free_reclaimable) >= get<2>(total_free_reclaimable));
+        
         // Some bytes should be free in the initial chain link
         assert(get<1>(total_free_reclaimable) > 0);
-        // But they should all be reclaimable, plus the block header
-        assert(get<1>(total_free_reclaimable) < get<2>(total_free_reclaimable));
+        // But they should all be reclaimable, including the block header
+        assert(get<1>(total_free_reclaimable) == get<2>(total_free_reclaimable));
         
         { 
         
@@ -598,8 +599,8 @@ void test_mapped_structs() {
             total_free_reclaimable = numbers_holder.get_usage();
             // Total bytes must be no less than free bytes
             assert(get<0>(total_free_reclaimable) >= get<1>(total_free_reclaimable));
-            // Total bytes must be no less than reclaimable bytes
-            assert(get<0>(total_free_reclaimable) >= get<2>(total_free_reclaimable));
+            // Free bytes must be no less than reclaimable bytes
+            assert(get<1>(total_free_reclaimable) >= get<2>(total_free_reclaimable));
             
             // At this point we've made it bigger than ever before and required
             // a new link probably, so nothing should be reclaimable.
@@ -620,8 +621,8 @@ void test_mapped_structs() {
             total_free_reclaimable = numbers_holder.get_usage();
             // Total bytes must be no less than free bytes
             assert(get<0>(total_free_reclaimable) >= get<1>(total_free_reclaimable));
-            // Total bytes must be no less than reclaimable bytes
-            assert(get<0>(total_free_reclaimable) >= get<2>(total_free_reclaimable));
+            // Free bytes must be no less than reclaimable bytes
+            assert(get<1>(total_free_reclaimable) >= get<2>(total_free_reclaimable));
             
             // At this point some memory should be reclaimable
             assert(get<2>(total_free_reclaimable) > 0);
@@ -646,8 +647,8 @@ void test_mapped_structs() {
         total_free_reclaimable = numbers_holder.get_usage();
         // Total bytes must be no less than free bytes
         assert(get<0>(total_free_reclaimable) >= get<1>(total_free_reclaimable));
-        // Total bytes must be no less than reclaimable bytes
-        assert(get<0>(total_free_reclaimable) >= get<2>(total_free_reclaimable));
+        // Free bytes must be no less than reclaimable bytes
+        assert(get<1>(total_free_reclaimable) >= get<2>(total_free_reclaimable));
         
         // No bytes should be reclaimable because we saved this through a mapping.
         assert(get<2>(total_free_reclaimable) == 0);


### PR DESCRIPTION
This adds automatic collection of trailing free blocks in file-backed `UniqueMappedPointer`s when they are closed.

It also adds a `get_usage()` method to the pointer itself, which returns total bytes mapped, number of bytes free (including allocator headers), and number of bytes reclaimable from the end (including allocator headers). So you can see how efficiently a data structure has been packed by the allocator. Wasted space fraction would be ((free - reclaimable) / total), assuming you save via mapped file.

I've added/implemented some `shrink_to_fit()` methods, but those might actually make total file size worse by allocating a new smaller block from the end and leaving a big free hole where the old larger allocation was. If it does look like we need to pack things more tightly, I can implement some smarter reallocators/repackers that try to move things to the front of the file.

@xchang1 Can you use this?