### PR TITLE
Fix non-optimized build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project(bdsg)
 
 option(RUN_DOXYGEN "Build Doxygen files required for Breathe-based docs" ON)
 option(BUILD_PYTHON_BINDINGS "Compile the bdsg Python module" ON)
+option(OPTIMIZE "Build with optimization" ON)
 
 # TODO: We can only do out-of-source builds!
 # TODO: How do we error out meaningfully on in-source builds?
@@ -25,9 +26,15 @@ set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
 # And GNU ideas of install directories
 include(GNUInstallDirs)
 
+if (OPTIMIZE)
 # Use all standard-compliant optimizations
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -g")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -g")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+endif ()
+# Always add debug info
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
   # assumes clang build

--- a/bdsg/src/mapped_structs.cpp
+++ b/bdsg/src/mapped_structs.cpp
@@ -27,6 +27,9 @@ namespace yomo {
 // Leave extra chain debugging checks off by default.
 bool Manager::check_chains = false;
 
+// This constant needs a compilation unit.
+const Manager::chainid_t Manager::NO_CHAIN;
+
 // we hide our LinkRecord in here because we can't forward-declare the MIO
 // stuff it stores.
 


### PR DESCRIPTION
@xchang1 said that libbdsg wouldn't work without optimization. This fixes a constant that was missing a compilation unit and lets you use `-DOPTIMIZE=OFF` on the CMake command line to build without optimization.