### PR TITLE
Prevent saved chains from being longer than they were when built in memory

### DIFF
--- a/bdsg/include/bdsg/internal/mapped_structs.hpp
+++ b/bdsg/include/bdsg/internal/mapped_structs.hpp
@@ -346,7 +346,7 @@ public:
     static void scan_chain(chainid_t chain, const std::function<void(const void*, size_t)>& iteratee);
     
     /**
-     * Dump information about free and allocated memory in the gievn chain.
+     * Dump information about free and allocated memory in the given chain.
      * Not thread safe!
      */
     static void dump(chainid_t chain);

--- a/bdsg/include/bdsg/internal/mapped_structs.hpp
+++ b/bdsg/include/bdsg/internal/mapped_structs.hpp
@@ -479,7 +479,7 @@ protected:
      * Block will either be the entire size of an existing file, or the given starting size.
      * Returns the chain ID and a flag for if there was data in an open file to read.
      *
-     * If link_data is set, the chain must not be filoe-backed, and link_data
+     * If link_data is set, the chain must not be file-backed, and link_data
      * it must point to a block of memory of length start_size already allocated
      * using malloc() and which can be freed using free(). The chain will take
      * ownership of the memory block.

--- a/bdsg/src/mapped_structs.cpp
+++ b/bdsg/src/mapped_structs.cpp
@@ -1503,11 +1503,26 @@ Manager::chainid_t Manager::copy_chain(chainid_t chain, int fd) {
     std::cerr << "Duplicating chain of total size " << total_size << " bytes" << std::endl;
 #endif
     
-    // Make the new chain with the appropriate size hint.
-    chainid_t new_chain = open_chain(fd, total_size).first;
+    if (fd) {
+        // Make sure to clear out the file we are writing to in case we are trying
+        // to overwrite a file.
+        if (ftruncate(fd, 0)) {
+            throw std::runtime_error("Could not truncate destination file: " + std::string(strerror(errno))); 
+        }
+    }
     
-    // Extend it to the required total size if it isn't long enough already
-    extend_chain_to(new_chain, total_size);
+    // Make the new chain with the appropriate size hint.
+    std::pair<chainid_t, bool> chain_info = open_chain(fd, total_size);
+    auto& new_chain = chain_info.first;
+    auto& had_data = chain_info.second;
+    
+    if (had_data) {
+        // If there's something there after we truncate, someone else is
+        // fighting us over the file.
+        throw std::runtime_error("Data was added to file at FD " + std::to_string(fd) + " while we were clearing it");
+    }
+    
+    // If we made a fresh new chain we know the first block will be total_size.
     
     // Copy all the data
     
@@ -1526,7 +1541,12 @@ Manager::chainid_t Manager::copy_chain(chainid_t chain, int fd) {
         // Until we are done, we need to copy an overlapping range between the two chains' links, as a block.
         // The block will reach to the end of a link in one or both chains.
         
-        // Make sure we have mapping addresses of an dpointers to records for
+        // TODO: We really should only ever use this to copy from more divided
+        // to more consolidated blocks; if a new boundary occurs in the new
+        // chain it could break up data that needs to be contiguous. Luckily,
+        // we're in charge of creating our destination chain.
+        
+        // Make sure we have mapping addresses of and pointers to records for
         // the current links.
         {
             // Get read access to manager data structures

--- a/bdsg/src/test_libbdsg.cpp
+++ b/bdsg/src/test_libbdsg.cpp
@@ -473,7 +473,79 @@ void test_mapped_structs() {
     cerr << "Mapped Structs tests successful!" << endl;
 }
         
-
+void test_int_vector() {
+    
+    // Make a thing to hold onto a test int vector.
+    bdsg::yomo::UniqueMappedPointer<bdsg::MappedIntVector> iv;
+    
+    // Have a function we can call to check its size.
+    auto save_and_check_size = [&](size_t expected_size) {
+        // Save it out
+        int fd = open("test.dat", O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+        iv.save(fd);
+        close(fd);
+        iv.dissociate();
+        
+        // Make sure that the file has the correct size
+        struct stat file_stats;
+        stat("test.dat", &file_stats);
+        cerr << "Observed file size of " << file_stats.st_size << " bytes" << endl;
+        assert(file_stats.st_size == expected_size);
+        
+        bdsg::yomo::UniqueMappedPointer<bdsg::MappedIntVector> iv2;
+        fd = open("test.dat", O_RDWR);
+        iv2.load(fd, "ints");
+        close(fd);
+        
+        // Make sure the re-loaded object has the correct usage.
+        std::tuple<size_t, size_t, size_t> total_free_reclaimable = iv2.get_usage();
+        size_t post_load_total_bytes = std::get<0>(total_free_reclaimable);
+        cerr << "Observed post-load size of " << post_load_total_bytes << " bytes" << endl;
+        assert(post_load_total_bytes == expected_size);
+    };
+    
+    
+    // Construct it
+    iv.construct("ints");
+    
+    // Give it a width
+    iv->width(20);
+    
+    // Make it big
+    size_t iv_size = 1024 * 1024 * 100;
+    for (size_t i = 1; i < iv_size; i *= 2) {
+        // Keep resizing it up and fragment the heap into many links.
+        iv->resize(i);
+    }
+    iv->resize(iv_size);
+    
+    for (size_t i = 0; i < iv_size; i++) {
+        // Fill it with a distinctive bit pattern
+        (*iv)[i] = 0xF0F0;
+    }
+    
+    // See how much memory we are using
+    std::tuple<size_t, size_t, size_t> total_free_reclaimable = iv.get_usage();
+    size_t required_bytes = std::get<0>(total_free_reclaimable) - std::get<2>(total_free_reclaimable);
+    cerr << std::get<0>(total_free_reclaimable) << " bytes in chain, "
+        << std::get<1>(total_free_reclaimable) << " bytes free, "
+        << std::get<2>(total_free_reclaimable) << " bytes reclaimable" << endl;
+    save_and_check_size(required_bytes);
+    
+    // Shrink it back down
+    iv->repack(16, iv_size);
+    total_free_reclaimable = iv.get_usage();
+    required_bytes = std::get<0>(total_free_reclaimable) - std::get<2>(total_free_reclaimable);
+    cerr << std::get<0>(total_free_reclaimable) << " bytes in chain, "
+        << std::get<1>(total_free_reclaimable) << " bytes free, "
+        << std::get<2>(total_free_reclaimable) << " bytes reclaimable" << endl;
+    save_and_check_size(required_bytes);
+    
+    
+    unlink("test.dat");
+    cerr << "Int Vector tests successful!" << endl;
+}
+        
 
 void test_serializable_handle_graphs() {
     
@@ -4025,6 +4097,7 @@ void test_hash_graph() {
 
 int main(void) {
     test_mapped_structs();
+    test_int_vector(); 
     test_packed_vector<PackedVector<>>();
     test_packed_vector<PackedVector<CompatBackend>>();
     test_packed_vector<PackedVector<MappedBackend>>();


### PR DESCRIPTION
Previously, trying to copy a chain onto a file that already existed would load the existing file as the first link in the chain. This could cause link breaks in contiguous data structures if that file was too small, or cause the resulting chain to be as big as the original file was if the file was too large.

Now we truncate away any data that's there already when trying to copy a chain to an FD.