### PR TITLE
Make bit vector unpack() more like SDSL's get_int()

### DIFF
--- a/bdsg/include/bdsg/internal/mapped_structs.hpp
+++ b/bdsg/include/bdsg/internal/mapped_structs.hpp
@@ -1788,9 +1788,9 @@ void CompatIntVector<Alloc>::pack(size_t index, uint64_t value, size_t width) {
     // Find the bit index we start at
     size_t start_bit = index * width;
     // And break into a slot number
-    size_t start_slot = start_bit / std::numeric_limits<uint64_t>::digits;
+    size_t start_slot = start_bit >> 6;
     // And a start bit in that slot
-    size_t start_slot_bit_offset = start_bit % std::numeric_limits<uint64_t>::digits;
+    size_t start_slot_bit_offset = start_bit& 0x3F;
     // And then save
     sdsl::bits::write_int(&data[start_slot], value, start_slot_bit_offset, width);
 }

--- a/bdsg/include/bdsg/internal/mapped_structs.hpp
+++ b/bdsg/include/bdsg/internal/mapped_structs.hpp
@@ -1798,9 +1798,9 @@ uint64_t CompatIntVector<Alloc>::unpack(size_t index, size_t width_override) con
     // Find the bit index we start at
     size_t start_bit = index * effective_width;
     // And break into a slot number
-    size_t start_slot = start_bit / std::numeric_limits<uint64_t>::digits;
+    size_t start_slot = start_bit >> 6;
     // And a start bit in that slot
-    size_t start_slot_bit_offset = start_bit % std::numeric_limits<uint64_t>::digits;
+    size_t start_slot_bit_offset = start_bit & 0x3F;
     
     // And then load
 #ifdef debug_bit_packing

--- a/bdsg/include/bdsg/internal/mapped_structs.hpp
+++ b/bdsg/include/bdsg/internal/mapped_structs.hpp
@@ -984,9 +984,9 @@ public:
     
     /**
      * Actual accessor method that gets the value at a position.
-     * Uses the given width override instead of the stored width to write the value, if set.
+     * Uses the given width override instead of the stored width to read the value.
      */
-    uint64_t unpack(size_t index, size_t width_override = 0) const;
+    uint64_t unpack(size_t index, size_t width_override) const;
     
     /**
      * Proxy that acts as a mutable reference to an entry in the vector.
@@ -1822,7 +1822,7 @@ CompatIntVector<Alloc>::Proxy::Proxy(CompatIntVector& parent, size_t index) : pa
 
 template<typename Alloc>
 CompatIntVector<Alloc>::Proxy::operator uint64_t () const {
-    return parent.unpack(index);
+    return parent.unpack(index, parent.bit_width);
 }
 
 template<typename Alloc>
@@ -1838,7 +1838,7 @@ CompatIntVector<Alloc>::ConstProxy::ConstProxy(const CompatIntVector& parent, si
 
 template<typename Alloc>
 CompatIntVector<Alloc>::ConstProxy::operator uint64_t () const {
-    return parent.unpack(index);
+    return parent.unpack(index, parent.bit_width);
 }
 
 template<typename Alloc>

--- a/bdsg/include/bdsg/internal/mapped_structs.hpp
+++ b/bdsg/include/bdsg/internal/mapped_structs.hpp
@@ -853,6 +853,19 @@ public:
     iterator end();
     const_iterator end() const;
     
+    // Allow fast access to the data block
+    
+    /// Get the pointer to the first item in the contiguous array, or nullptr
+    /// if no array is allocated.
+    inline T* get_first() {
+        return (T*)first;
+    }
+    /// Get the pointer to the first item in the contiguous array, or nullptr
+    /// if no array is allocated.
+    inline const T* get_first() const {
+        return (const T*)first;
+    }
+    
     // Compatibility with SDSL-lite serialization
     
     /**
@@ -1790,7 +1803,7 @@ uint64_t CompatIntVector<Alloc>::unpack(size_t index, size_t width) const {
     // Find the bit index we start at
     size_t start_bit = index * width;
     // And then load
-    return sdsl::bits::read_int(&data[start_bit >> 6], start_bit & 0x3F, width);
+    return sdsl::bits::read_int(data.get_first() + (start_bit >> 6), start_bit & 0x3F, width);
 }
 
 template<typename Alloc>

--- a/bdsg/include/bdsg/internal/mapped_structs.hpp
+++ b/bdsg/include/bdsg/internal/mapped_structs.hpp
@@ -1787,12 +1787,7 @@ void CompatIntVector<Alloc>::pack(size_t index, uint64_t value, size_t width) {
     
     // Find the bit index we start at
     size_t start_bit = index * width;
-    // And break into a slot number
-    size_t start_slot = start_bit >> 6;
-    // And a start bit in that slot
-    size_t start_slot_bit_offset = start_bit& 0x3F;
-    // And then save
-    sdsl::bits::write_int(&data[start_slot], value, start_slot_bit_offset, width);
+    sdsl::bits::write_int(data.get_first() + (start_bit >> 6), value, start_bit & 0x3F, width);
 }
 
 template<typename Alloc>

--- a/bdsg/include/bdsg/internal/mapped_structs.hpp
+++ b/bdsg/include/bdsg/internal/mapped_structs.hpp
@@ -984,9 +984,9 @@ public:
     
     /**
      * Actual accessor method that gets the value at a position.
-     * Uses the given width override instead of the stored width to read the value.
+     * Uses the given width instead of the stored width to read the value.
      */
-    uint64_t unpack(size_t index, size_t width_override) const;
+    uint64_t unpack(size_t index, size_t width) const;
     
     /**
      * Proxy that acts as a mutable reference to an entry in the vector.
@@ -1782,37 +1782,15 @@ void CompatIntVector<Alloc>::pack(size_t index, uint64_t value, size_t width_ove
     // And a start bit in that slot
     size_t start_slot_bit_offset = start_bit % std::numeric_limits<uint64_t>::digits;
     // And then save
-#ifdef debug_bit_packing
-    std::cerr << "Write " << value
-        << " of width " << effective_width
-        << " at bit " << start_slot_bit_offset
-        << " in slot " << start_slot << endl; 
-#endif
     sdsl::bits::write_int(&data[start_slot], value, start_slot_bit_offset, effective_width);
 }
 
 template<typename Alloc>
-uint64_t CompatIntVector<Alloc>::unpack(size_t index, size_t width_override) const {
-    // Decide how wide to interpret the items as
-    size_t effective_width = width_override ? width_override : (size_t) bit_width;
+uint64_t CompatIntVector<Alloc>::unpack(size_t index, size_t width) const {
     // Find the bit index we start at
-    size_t start_bit = index * effective_width;
-    // And break into a slot number
-    size_t start_slot = start_bit >> 6;
-    // And a start bit in that slot
-    size_t start_slot_bit_offset = start_bit & 0x3F;
-    
+    size_t start_bit = index * width;
     // And then load
-#ifdef debug_bit_packing
-    std::cerr << "Read value of width " << effective_width
-        << " at bit " << start_slot_bit_offset
-        << " in slot " << start_slot << ": ";
-#endif
-    uint64_t value = sdsl::bits::read_int(&data[start_slot], start_slot_bit_offset, effective_width);
-#ifdef debug_bit_packing
-    std::cerr << value << std::endl;
-#endif
-    return value;
+    return sdsl::bits::read_int(&data[start_bit >> 6], start_bit & 0x3F, width);
 }
 
 template<typename Alloc>

--- a/bdsg/include/bdsg/internal/mapped_structs.hpp
+++ b/bdsg/include/bdsg/internal/mapped_structs.hpp
@@ -1787,6 +1787,8 @@ void CompatIntVector<Alloc>::pack(size_t index, uint64_t value, size_t width) {
     
     // Find the bit index we start at
     size_t start_bit = index * width;
+    // Use the last 6 bits (up to 64) for the offset in the 64-bit word, and
+    // the others for the word number.
     sdsl::bits::write_int(data.get_first() + (start_bit >> 6), value, start_bit & 0x3F, width);
 }
 
@@ -1794,7 +1796,9 @@ template<typename Alloc>
 uint64_t CompatIntVector<Alloc>::unpack(size_t index, size_t width) const {
     // Find the bit index we start at
     size_t start_bit = index * width;
-    // And then load
+    // And then load.
+    // Use the last 6 bits (up to 64) for the offset in the 64-bit word, and
+    // the others for the word number.
     return sdsl::bits::read_int(data.get_first() + (start_bit >> 6), start_bit & 0x3F, width);
 }
 

--- a/bdsg/include/bdsg/internal/mapped_structs.hpp
+++ b/bdsg/include/bdsg/internal/mapped_structs.hpp
@@ -1802,45 +1802,6 @@ uint64_t CompatIntVector<Alloc>::unpack(size_t index, size_t width_override) con
     // And a start bit in that slot
     size_t start_slot_bit_offset = start_bit % std::numeric_limits<uint64_t>::digits;
     
-    if (yomo::Manager::check_chains) {
-        // Do some bounds checking
-    
-        // Work out if we span into the next slot
-        bool into_next_slot = (start_slot_bit_offset + effective_width > std::numeric_limits<uint64_t>::digits);
-        if (start_slot >= data.size() || (into_next_slot && start_slot + 1 >= data.size())) {
-            // We want to go out of range of the vector.
-            throw std::out_of_range("Reading item " + std::to_string(index) +
-                " of width " + std::to_string(effective_width) + " accesses slot " + std::to_string(start_slot) +
-                (into_next_slot ? ("and slot " + std::to_string(into_next_slot + 1)) : "") +
-                " but we only have " + std::to_string(data.size()) + " slots and " +
-                std::to_string(size()) + " items");
-        }
-        
-        // Define the memory range we plan to access, inclusive
-        const uint64_t* access_first = &data[start_slot];
-        const uint64_t* access_last =  access_first + into_next_slot;
-        
-        // Make sure we aren't trying to go across chains
-        auto our_chain = yomo::Manager::get_chain(this);
-        for (const uint64_t* access_addr = access_first; access_addr != access_last + 1; access_addr++) {
-            // For each slot we need to read
-            
-            auto other_chain = yomo::Manager::get_chain(access_addr);
-            
-            if (other_chain != our_chain) {
-                // We're accessing something past the end of the chain somehow.
-                std::stringstream msg;
-                msg << "error[CompatIntVector]: Attempting to access address " << access_addr
-                    << " for vector at " << this << " with data at " << &data[0]
-                    << " but we are in chain " << our_chain
-                    << " and accessed address is in chain " << other_chain
-                    << ". Is the entire file mapped?" << std::endl;
-                yomo::Manager::dump_links(msg);
-                throw std::out_of_range(msg.str());
-            }
-        }
-    }
-    
     // And then load
 #ifdef debug_bit_packing
     std::cerr << "Read value of width " << effective_width

--- a/bdsg/src/test_libbdsg.cpp
+++ b/bdsg/src/test_libbdsg.cpp
@@ -220,8 +220,9 @@ void test_bit_packing() {
         }
         return test_int;
     };
-    
+     
     // Make sure we can zero everything
+    stage = "zero";
     for (size_t i = 0; i < 2; i++) {
         set_both(i * 64, 0, 64);
     }
@@ -230,6 +231,7 @@ void test_bit_packing() {
     }
     
     // Make sure we can put a bit pattern and get back the right values at all bit widths.
+    stage = "pattern";
     for (size_t i = 0; i < 2; i++) {
         set_both(i * 64, 0xCAFEBEBECACAF0F0, 64);
     }

--- a/bdsg/src/test_libbdsg.cpp
+++ b/bdsg/src/test_libbdsg.cpp
@@ -478,11 +478,7 @@ void test_mapped_structs() {
     assert(yomo::Manager::count_links() == 0);
     
     {
-        // Make sure our bit-packing vector checks bound
-        
-        // Make sure checks that prevent opening corrupted files aren't on.
-        bool saved = bdsg::yomo::Manager::check_chains;
-        bdsg::yomo::Manager::check_chains = false;
+        // Make sure our bit-packing vector can self-test
         
         // Make a vector
         bdsg::yomo::UniqueMappedPointer<MappedIntVector> vec;
@@ -509,19 +505,8 @@ void test_mapped_structs() {
         // Reload
         vec.load(tmpfd, "");
         
-        // Turn on checking of accesses
-        bdsg::yomo::Manager::check_chains = true;
         try {
-            verify_to(*vec, 1000, 1);
-            // We shouldn't be able to complete this; we should run off the end of the chain.
-            assert(false);
-        } catch (std::out_of_range& e) {
-            // This is the exception we expect to get.
-        }
-        bdsg::yomo::Manager::check_chains = false;
-        
-        try {
-            // We shouldn't pass heap verification even when not checking accesses.
+            // We shouldn't pass heap verification.
             vec.check_heap_integrity();
             assert(false);
         } catch (std::runtime_error& e) {
@@ -532,8 +517,6 @@ void test_mapped_structs() {
         
         close(tmpfd);
         unlink(filename);
-        
-        bdsg::yomo::Manager::check_chains = saved;
     }
     
     assert(yomo::Manager::count_chains() == 0);

--- a/bdsg/src/test_libbdsg.cpp
+++ b/bdsg/src/test_libbdsg.cpp
@@ -4077,7 +4077,6 @@ void test_hash_graph() {
 
 int main(void) {
     test_bit_packing();
-    return 0;
     test_mapped_structs();
     test_packed_vector<PackedVector<>>();
     test_packed_vector<PackedVector<CompatBackend>>();


### PR DESCRIPTION
This ought to make `bdsg::CompatIntVector<bdsg::yomo::Allocator<unsigned long> >::unpack(unsigned long, unsigned long) const (vg: mapped_structs.hpp, ...)` stop taking 36% of the time in `get_nodes`.