### PR TITLE
Add step->path cache to the reference overlay

### DIFF
--- a/bdsg/include/bdsg/overlays/packed_reference_path_overlay.hpp
+++ b/bdsg/include/bdsg/overlays/packed_reference_path_overlay.hpp
@@ -35,6 +35,9 @@ public:
     // finding visits on nodes is slow. We override the reverse lookups to go
     // fron graph nodes to paths.
 
+    /// overload this to use the cache 
+    virtual path_handle_t get_path_handle_of_step(const step_handle_t& step_handle) const;
+
 protected:
     
     // PathHandleGraph interface
@@ -87,6 +90,13 @@ protected:
     /// This holds the indexes, each of which belongs to a path or collection
     /// of short paths. Order is the same as "indexes" in the base class.
     vector<PathVisitIndex> visit_indexes;
+
+    /// Speed up get_path_handle_of_step() by caching the path of every step (!)
+    /// There's already a step hash in the parent position overlay but it's
+    /// indexed by path handle, which defeats the purpose here. todo: certainly
+    /// room for improvement with a big refactor
+    unique_ptr<boomphf::mphf<step_handle_t, StepHash>> step_to_rank;
+    PackedVector<> step_rank_to_path;
 };
 
 }


### PR DESCRIPTION
quoting @adamnovak

_I guess we have to come up with an overlay design that can let us go from step handle to path handle without a locate().
Which I think means we might need to copy all the step handles from the backing graph into a map somewhere._ 

This PR does just that (in a pretty naive way): add a step->path cache in order to speed up `PackedReferencePathOverlay::get_path_handle_of_step()`

on a chr10 deconstruct test from "chicken-pangenome-sep23` with 8 cores on my desktop

```
xg/gbwt:      47 s     439,220 kb
gbz (before): 224 s    841,624 kb
gbz (now):    61 s     885,008 kb
```


Resolves #172 