### PR TITLE
Add a maximum number of warnings about hitting the snarl size limit

### DIFF
--- a/bdsg/include/bdsg/snarl_distance_index.hpp
+++ b/bdsg/include/bdsg/snarl_distance_index.hpp
@@ -835,7 +835,7 @@ private:
      * Otherwise, for snarls with more children than snarl_size_limit, only store the distances
      * that include boundary nodes (OVERSIZED_SNARL)
      */
-    size_t snarl_size_limit = 1000;
+    size_t snarl_size_limit = 5000;
     uint32_t magic_number = 1738636486;
 public:
     void set_snarl_size_limit (size_t size) {snarl_size_limit=size;}

--- a/bdsg/include/bdsg/snarl_distance_index.hpp
+++ b/bdsg/include/bdsg/snarl_distance_index.hpp
@@ -11,6 +11,7 @@
 #include <bdsg/internal/mapped_structs.hpp>
 #include <string>
 #include <numeric>
+#include <atomic>
 #include <arpa/inet.h>
  /**
   * This defines the distance index, which also serves as a snarl tree that implements libhandlegraph's 
@@ -836,7 +837,10 @@ private:
      * that include boundary nodes (OVERSIZED_SNARL)
      */
     size_t snarl_size_limit = 5000;
-    uint32_t magic_number = 1738636486;
+    static const int max_num_size_limit_warnings = 100;
+    std::atomic<int> size_limit_warnings = 0;
+    static const uint32_t magic_number = 1738636486;
+    
 public:
     void set_snarl_size_limit (size_t size) {snarl_size_limit=size;}
 

--- a/bdsg/include/bdsg/snarl_distance_index.hpp
+++ b/bdsg/include/bdsg/snarl_distance_index.hpp
@@ -838,7 +838,7 @@ private:
      */
     size_t snarl_size_limit = 5000;
     static const int max_num_size_limit_warnings = 100;
-    std::atomic<int> size_limit_warnings = 0;
+    std::atomic<int> size_limit_warnings{0};
     static const uint32_t magic_number = 1738636486;
     
 public:

--- a/bdsg/src/snarl_distance_index.cpp
+++ b/bdsg/src/snarl_distance_index.cpp
@@ -1066,7 +1066,14 @@ size_t SnarlDistanceIndex::distance_in_parent(const net_handle_t& parent,
             //If this is an oversized snarl and we're looking for internal distances, then we didn't store the
             //distance and we have to find it using dijkstra's algorithm
             if (graph == nullptr) {
-                cerr << "warning: trying to find the distance in an oversized snarl without a graph. Returning inf" << endl;
+                int warning_num = const_cast<SnarlDistanceIndex*>(this)->size_limit_warnings++;
+                if (warning_num < max_num_size_limit_warnings) {
+                    std::string msg = "warning: trying to find the distance in an oversized snarl without a graph. Returning inf\n";
+                    if (warning_num + 1 == max_num_size_limit_warnings) {
+                        msg += "suppressing further warnings\n";
+                    }
+                    std::cerr << msg;
+                }
                 return std::numeric_limits<size_t>::max();
             }
             handle_t handle1 = is_node(child1) ? get_handle(child1, graph) : get_handle(get_bound(child1, !child_ends_at_start1, false), graph); 

--- a/bdsg/src/snarl_distance_index.cpp
+++ b/bdsg/src/snarl_distance_index.cpp
@@ -1066,13 +1066,15 @@ size_t SnarlDistanceIndex::distance_in_parent(const net_handle_t& parent,
             //If this is an oversized snarl and we're looking for internal distances, then we didn't store the
             //distance and we have to find it using dijkstra's algorithm
             if (graph == nullptr) {
-                int warning_num = const_cast<SnarlDistanceIndex*>(this)->size_limit_warnings++;
-                if (warning_num < max_num_size_limit_warnings) {
-                    std::string msg = "warning: trying to find the distance in an oversized snarl without a graph. Returning inf\n";
-                    if (warning_num + 1 == max_num_size_limit_warnings) {
-                        msg += "suppressing further warnings\n";
+                if (size_limit_warnings.load() < max_num_size_limit_warnings) {
+                    int warning_num = const_cast<SnarlDistanceIndex*>(this)->size_limit_warnings++;
+                    if (warning_num < max_num_size_limit_warnings) {
+                        std::string msg = "warning: trying to find the distance in an oversized snarl without a graph. Returning inf\n";
+                        if (warning_num + 1 == max_num_size_limit_warnings) {
+                            msg += "suppressing further warnings\n";
+                        }
+                        std::cerr << msg;
                     }
-                    std::cerr << msg;
                 }
                 return std::numeric_limits<size_t>::max();
             }


### PR DESCRIPTION
In complicated graphs, we were getting complaints that this could generate GB of warning messages. 