### PR TITLE
Allow preloading the distance index from disk

### DIFF
--- a/bdsg/include/bdsg/snarl_distance_index.hpp
+++ b/bdsg/include/bdsg/snarl_distance_index.hpp
@@ -156,6 +156,12 @@ public:
 
     virtual uint32_t get_magic_number() const;
     std::string get_prefix() const;
+    
+    /// Allow for preloading the index for more accurate timing of algorithms
+    /// that use it, if it fits in memory. If blocking is true, waits for the
+    /// index to be paged in. Otherwise, just tells the OS that we will want to
+    /// use it.
+    void preload(bool blocking = false) const;
 
 
 ////////////////////////////////////  How we define different properties of a net handle

--- a/bdsg/src/mapped_structs.cpp
+++ b/bdsg/src/mapped_structs.cpp
@@ -898,8 +898,6 @@ void Manager::preload_chain(chainid_t chain, bool blocking) {
     // madvise calls need to be page-aligned, so get the page size
     intptr_t page_size = (intptr_t) getpagesize();
     
-    std::cerr << "Preloading: " << chain << " " << blocking << std::endl;
-    
     // We may have a way to use madvise to populate a mapping. If we think so, this will be nonzero.
     int populate_read_advice = 0;
 #ifndef __APPLE__

--- a/bdsg/src/mapped_structs.cpp
+++ b/bdsg/src/mapped_structs.cpp
@@ -894,6 +894,94 @@ void* Manager::allocate_from_same_chain(void* here, size_t bytes) {
     return allocate_from(get_chain(here), bytes);
 }
 
+void Manager::preload_chain(chainid_t chain, bool blocking) {
+    // madvise calls need to be page-aligned, so get the page size
+    intptr_t page_size = (intptr_t) getpagesize();
+    
+    scan_chain(chain, [&](void* link_start, size_t link_length) {
+        // For each link in the chain
+        
+        // Work out the page it starts on
+        intptr_t link_start_page = (intptr_t)link_start / page_size;
+        // How much into that page it starts
+        intptr_t link_remainder = (intptr_t)link_start % page_size;
+        // And the page after the page it ends on. If we have a final partial page, go after that.
+        intptr_t link_past_end_page = ((intptr_t)link_start + link_length) / page_size + (((intptr_t)link_start + link_length) % page_size == 0) ? 0 : 1;
+        if (link_remainder > 0) {
+            // The link doesn't start on a page boundary.
+            // Ignore the part of the link that is before the first page boundary, if any exists.
+            link_start_page++;
+        }
+        
+        // Now we need to operate on all the pages from link_start_page,
+        // inclusive, to link_past_end_page, exclusive.
+        if (link_start_page >= link_past_end_page) {
+            // There actually aren't any pages to work on in this link.
+            return;
+        }
+        
+        if (blocking) {
+#ifndef __APPLE__
+            // Linux has an MADV_POPULATE_READ in kernel 5.14+ that will wait
+            // for everything to be loaded from disk once.
+            
+#ifdef MADV_POPULATE_READ
+            // The new advice value for a blocking fake read is in the C library.
+            int populate_read_advice = MADV_POPULATE_READ;
+#else
+            // Try guessing the number and hoping it is not anything else.
+            // See https://patchwork.kernel.org/project/linux-mm/patch/20210701015228.QXA77Jpli%25akpm@linux-foundation.org/
+            int populate_read_advice = 22;
+#endif
+
+            // Make the call
+            int result = madvise(link_start_page * page_size, (link_past_end_page - link_start_page) * page_size, populate_read_advice);
+            
+            if (result == 0) {
+                // It worked!
+                return;
+            }
+            
+            // Otherwise the call failed
+            auto madvise_error = errno;
+            
+            switch (madvise_error) {
+#ifdef MADV_POPULATE_READ
+            case EINVAL:
+                // We made up an advice so it's likely it doesn't exist.
+                std::cerr << "warning[yomo::Manager::preload_chain] Cannot prepopulate link with syscall; falling back to reading each page." << std::endl;
+                break;
+#endif
+            default:
+                // This is a problem
+                throw std::runtime_error(std::string("Could not prefault memory: ") + std::string(strerror(madvise_error));
+            }
+            
+#endif
+            
+            // If we get here we need to do our own read on every page
+            for (intptr_t addr = link_start_page * page_size; addr < link_past_end_page * page_size; addr += page_size) {
+                // Get a pointer that the compiler doesn't try to reason about
+                volatile char* to_read_from = (volatile char*) addr;
+                // Access it and discard the result
+                (void) *to_read_from;
+            }
+        } else {
+            // Just tell the memory management subsystem we will want this
+            int result = madvise(link_start_page * page_size, (link_past_end_page - link_start_page) * page_size, MADV_WILLNEED);
+            
+            if (result == 0) {
+                // It worked!
+                return;
+            }
+            
+            // Otherwise the call failed
+            auto madvise_error = errno;
+            throw std::runtime_error(std::string("Could not mark memory needed: ") + std::string(strerror(madvise_error));
+        }
+    });
+}
+
 void Manager::deallocate(void* address) {
 #ifdef debug_manager
     std::cerr << "Deallocate at " << address << std::endl;

--- a/bdsg/src/snarl_distance_index.cpp
+++ b/bdsg/src/snarl_distance_index.cpp
@@ -855,6 +855,9 @@ std::string SnarlDistanceIndex::get_prefix() const {
     return as_string;
 }
 
+void SnarlDistanceIndex::preload(bool blocking) const {
+    snarl_tree_records.preload(blocking);
+}
 
 size_t SnarlDistanceIndex::distance_in_parent(const net_handle_t& parent, 
         const net_handle_t& child1, const net_handle_t& child2, const HandleGraph* graph, size_t distance_limit) const {

--- a/bdsg/src/test_libbdsg.cpp
+++ b/bdsg/src/test_libbdsg.cpp
@@ -282,6 +282,10 @@ void test_mapped_structs() {
             // We should start empty
             assert(vec1.size() == 0);
             
+            // We should be able to preload without crashing
+            numbers_holder.preload();
+            numbers_holder.preload(true);
+            
             // We should be able to expand.
             vec1.resize(100);
             assert(vec1.size() == 100);
@@ -312,6 +316,9 @@ void test_mapped_structs() {
             fill_to(vec1, 1000, 1);
             verify_to(vec1, 1000, 1);
             
+            // And to preload without crashing
+            numbers_holder.preload();
+            numbers_holder.preload(true);
         }
         
         // We're going to need a temporary file
@@ -328,6 +335,10 @@ void test_mapped_structs() {
             // We should have the same data
             assert(vec2.size() == 1000);
             verify_to(vec2, 1000, 1);
+            
+            // We should be able to preload without crashing
+            numbers_holder.preload();
+            numbers_holder.preload(true);
             
             // We should still be able to modify it.
             vec2.resize(4000);
@@ -395,6 +406,10 @@ void test_mapped_structs() {
         
         {
             auto& vec4 = *numbers_holder;
+            
+            // We should be able to preload without crashing
+            numbers_holder.preload();
+            numbers_holder.preload(true);
             
             // When we reload we should see the last thing we wrote before dissociating.
             assert(vec4.size() == 4000);


### PR DESCRIPTION
This adds machinery to the distance index and the memory-mapping chains to let you blockingly bring the whole index into memory, or else hint that it should be all brought into memory. This can be a lot faster than waiting for the kernel to fault all the pages as they are accessed, because it gets to use sequential and not random disk reads.