### PR TITLE
Map read-only when needed

### DIFF
--- a/bdsg/include/bdsg/internal/mapped_structs.hpp
+++ b/bdsg/include/bdsg/internal/mapped_structs.hpp
@@ -194,7 +194,9 @@ public:
      * begin with the given prefix, if specified, or an error will occur.
      *
      * Modifications to the chain will affect the file, and it will grow as
-     * necessary.
+     * necessary. If the file is read-only, and an attempt is made to modify
+     * the chain or any data in it, a memory protection error (segmentation
+     * fault) will occur.
      *
      * The Manager will not take ownership of the file descriptor.
      *
@@ -339,6 +341,12 @@ public:
      * Return the total number of bytes in the given chain.
      */
     static size_t get_chain_size(chainid_t chain);
+    
+    /**
+     * Return true if the chain cna be written to, and false if it can only be
+     * accessed read-only.
+     */
+    static bool is_chain_writable(chainid_t chain);
     
     /**
      * Get statistics about the memory in a chain. Returns all 0s if not a managed chain.
@@ -492,6 +500,9 @@ protected:
      * it must point to a block of memory of length start_size already allocated
      * using malloc() and which can be freed using free(). The chain will take
      * ownership of the memory block.
+     *
+     * If the FD is not writable, this will be detected, and memory will be
+     * mapped read-only.
      */
     static std::pair<chainid_t, bool> open_chain(int fd = 0, size_t start_size = BASE_SIZE, void* link_data = nullptr);
     

--- a/bdsg/include/bdsg/snarl_distance_index.hpp
+++ b/bdsg/include/bdsg/snarl_distance_index.hpp
@@ -126,10 +126,23 @@ using namespace handlegraph;
 /**
   * The distance index, which also acts as a snarl decomposition.
   *
-  * The distance index provides an interface to traverse the snarl tree and to find minimum distances
-  * between two sibling nodes in the snarl tree (eg between two chains that are children of the same snarl).
+  * The distance index provides an interface to traverse the snarl tree and to
+  * find minimum distances between two sibling nodes in the snarl tree (eg
+  * between two chains that are children of the same snarl).
   *
-  * It also provides a method for quickly calculating the minimum distance between two positions on the graph.
+  * It also provides a method for quickly calculating the minimum distance
+  * between two positions on the graph.
+  *
+  * The implementation here is tightly coupled with the filling-in code in vg
+  * (see vg::fill_in_distance_index()). To make a SnarlDistanceIndex that
+  * actually works, you have to construct the object, and then call
+  * get_snarl_tree_records() with zero or more TemporaryDistanceIndex objects
+  * for connected components, and a graph.
+  *
+  * The TemporaryDistanceIndex needs to have a variety of TemporaryRecord
+  * implementation classes (TemporaryChainRecord, TemporarySnarlRecord,
+  * TemporaryNodeRecord) set up and added to it; this all has to be done "by
+  * hand", as it were, because no code is in this library to help you do it.
   *
   */
 class SnarlDistanceIndex : public SnarlDecomposition, public TriviallySerializable {

--- a/bdsg/src/test_libbdsg.cpp
+++ b/bdsg/src/test_libbdsg.cpp
@@ -4410,7 +4410,7 @@ void test_snarl_distance_index() {
 }
 
 int main(void) {
-    /*test_bit_packing();
+    test_bit_packing();
     test_mapped_structs();
     test_int_vector(); 
     test_packed_vector<PackedVector<>>();
@@ -4435,6 +4435,6 @@ int main(void) {
     test_packed_subgraph_overlay();
     test_multithreaded_overlay_construction();
     test_mapped_packed_graph();
-    test_hash_graph();*/
+    test_hash_graph();
     test_snarl_distance_index();
 }


### PR DESCRIPTION
This changes the memory-mapping system to detect when a file is not writable, and map it read-only instead of read-write.

I've turned off setting the direct-jump flags in the pointers and trying to trim the file on close, in those cases, but the read-only-ness *isn't* enforced with const-ness of the UniqueMappedPointer and will show up as a segfault if you load from a read-only file and then try to write.