### PR TITLE
Enabled the creation of empty handles for PackedGraphs

### DIFF
--- a/bdsg/include/bdsg/internal/base_packed_graph.hpp
+++ b/bdsg/include/bdsg/internal/base_packed_graph.hpp
@@ -1191,10 +1191,6 @@ handle_t BasePackedGraph<Backend>::create_handle(const string& sequence) {
 template<typename Backend>
 handle_t BasePackedGraph<Backend>::create_handle(const string& sequence, const nid_t& id) {
     
-    if (sequence.empty()) {
-        throw std::runtime_error("error:[BasePackedGraph] tried to create an empty node with ID " + std::to_string(id));
-    }
-    
     if (id <= 0) {
         throw std::runtime_error("error:[BasePackedGraph] tried to create a node with non-positive ID " + std::to_string(id));
     }


### PR DESCRIPTION
Removed the error preventing the creation of empty handles for PackedGraphs.