### PR TITLE
Add missing jansson link in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ INSTALL_PREFIX?=/usr/local
 INSTALL_LIB_DIR=$(INSTALL_PREFIX)/lib
 INSTALL_INC_DIR=$(INSTALL_PREFIX)/include
 
-LIB_FLAGS:=-lbdsg -lsdsl -lhandlegraph
+LIB_FLAGS:=-lbdsg -lsdsl -lhandlegraph -ljansson
 
 OBJS = $(OBJ_DIR)/eades_algorithm.o 
 OBJS += $(OBJ_DIR)/hash_graph.o 


### PR DESCRIPTION
The flag to link libjansson was missing in the Makefile build.