### PR TITLE
Odds and ends for reference path overlay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ OBJS += $(OBJ_DIR)/mapped_structs.o
 OBJS += $(OBJ_DIR)/packed_graph.o 
 OBJS += $(OBJ_DIR)/path_position_overlays.o 
 OBJS += $(OBJ_DIR)/packed_path_position_overlay.o
+OBJS += $(OBJ_DIR)/reference_path_overlay.o
 OBJS += $(OBJ_DIR)/packed_reference_path_overlay.o
 OBJS += $(OBJ_DIR)/path_subgraph_overlay.o
 OBJS += $(OBJ_DIR)/subgraph_overlay.o

--- a/bdsg/include/bdsg/overlays/overlay_helper.hpp
+++ b/bdsg/include/bdsg/overlays/overlay_helper.hpp
@@ -14,6 +14,7 @@
 #include "bdsg/overlays/vectorizable_overlays.hpp"
 #include "bdsg/overlays/packed_path_position_overlay.hpp"
 #include "bdsg/overlays/packed_reference_path_overlay.hpp"
+#include "bdsg/overlays/reference_path_overlay.hpp"
 
 namespace bdsg {
     
@@ -31,7 +32,8 @@ typedef OverlayHelper<PathPositionHandleGraph, PackedPositionOverlay, PathHandle
 /// interface, but optimized for using the paths as reference coordinates, with
 /// acceleration for some queries that might be slow in, for example, a
 /// GBWTGraph.
-typedef OverlayHelper<PathPositionHandleGraph, PackedReferencePathOverlay, PathHandleGraph> ReferencePathOverlayHelper;
+typedef OverlayHelper<PathPositionHandleGraph, ReferencePathOverlay, PathHandleGraph> ReferencePathOverlayHelper;
+typedef OverlayHelper<PathPositionHandleGraph, PackedReferencePathOverlay, PathHandleGraph> PackedReferencePathOverlayHelper;
 
 /// Helper to ensure that a HandleGraph has the RankedHandleGraph interface.
 // TODO: If we write a dedicated, less powerful RankedOverlay, use that here instead.

--- a/bdsg/include/bdsg/overlays/overlay_helper.hpp
+++ b/bdsg/include/bdsg/overlays/overlay_helper.hpp
@@ -13,8 +13,8 @@
 
 #include "bdsg/overlays/vectorizable_overlays.hpp"
 #include "bdsg/overlays/packed_path_position_overlay.hpp"
-#include "bdsg/overlays/packed_reference_path_overlay.hpp"
 #include "bdsg/overlays/reference_path_overlay.hpp"
+#include "bdsg/overlays/packed_reference_path_overlay.hpp"
 
 namespace bdsg {
     


### PR DESCRIPTION
The previous PR was missing an overlay helper for the `ReferencePathOverlay` and also had a bug in the `make` build.