### PR TITLE
Actually expose the PackedGraph batch path destroy function

### DIFF
--- a/bdsg/include/bdsg/internal/base_packed_graph.hpp
+++ b/bdsg/include/bdsg/internal/base_packed_graph.hpp
@@ -2619,6 +2619,10 @@ template<typename Backend>
 void BasePackedGraph<Backend>::destroy_paths(const std::vector<path_handle_t>& paths) {
     
     std::unordered_set<path_handle_t> paths_set(paths.begin(), paths.end());
+    path_handle_t first_path = as_path_handle(-1);
+    if (paths.size() == 1) {
+        first_path = paths.front();
+    }
     
     PackedSet<Backend> nodes_visited;
     
@@ -2649,7 +2653,8 @@ void BasePackedGraph<Backend>::destroy_paths(const std::vector<path_handle_t>& p
             size_t prev = 0;
             size_t here = path_membership_node_iv.get(node_member_idx);
             while (here) {
-                if (paths_set.count(as_path_handle(get_membership_path(here)))) {
+                auto path_here = as_path_handle(get_membership_path(here));
+                if (paths.size() == 1 ? path_here == first_path : paths_set.count(path_here)) {
                     // this is a membership record for a path that we're deleting
                     if (prev == 0) {
                         // this was the first record, set following one to be the head

--- a/bdsg/include/bdsg/internal/graph_proxy_mutable_path_deletable_handle_graph_fragment.classfragment
+++ b/bdsg/include/bdsg/internal/graph_proxy_mutable_path_deletable_handle_graph_fragment.classfragment
@@ -104,6 +104,13 @@ public:
     virtual void destroy_path(const path_handle_t& path) {
         this->get()->destroy_path(path);
     }
+    
+    /**
+     * Destroy the given paths. Invalidates handles to the paths and their steps.
+     */
+    virtual void destroy_paths(const std::vector<path_handle_t>& paths) {
+        this->get()->destroy_paths(paths);
+    }
 
     /**
      * Create a path with the given name. The caller must ensure that no path

--- a/bdsg/src/hash_graph.cpp
+++ b/bdsg/src/hash_graph.cpp
@@ -603,6 +603,10 @@ namespace bdsg {
         for (auto path : paths) {
             path_ids.emplace(as_integer(path));
         }
+        int64_t first_path = -1;
+        if (path_ids.size() == 1) {
+            first_path = *path_ids.begin();
+        }
         unordered_set<nid_t> nodes_visited;
         
         for (auto path : paths) {
@@ -618,7 +622,7 @@ namespace bdsg {
                 }
                 vector<path_mapping_t*>& node_occs = graph[get_id(mapping->handle)].occurrences;
                 for (size_t i = 0; i < node_occs.size(); ) {
-                    if (path_ids.count(node_occs[i]->path_id)) {
+                    if (first_path != -1 ? node_occs[i]->path_id == first_path : path_ids.count(node_occs[i]->path_id)) {
                         node_occs[i] = node_occs.back();
                         node_occs.pop_back();
                     }


### PR DESCRIPTION
The `BasePackedGraph` implementation of `destroy_paths` is no longer blocked by the default implementation in `GraphProxy`. I also did a micro-optimization that should mostly restore the speed of deleting a single path.