### PR TITLE
Fix Binder for GCC 13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,7 +192,7 @@ if (BUILD_PYTHON_BINDINGS)
 
     # Binder (because some generated bindings depend on headers packaged with Binder)
     # See also: Binder commit defined in make_and_run_binder.py which actually generates bindings.
-    set(BINDER_COMMIT d5ef611f80cc91848db1fbd09d26b97013aa4db5)
+    set(BINDER_COMMIT b6cac94c78ade6c6ffcbda629ffa520561a31788)
     ExternalProject_Add(binder
       GIT_REPOSITORY "https://github.com/adamnovak/binder.git"
       GIT_TAG "${BINDER_COMMIT}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,10 +189,13 @@ target_include_directories(sparsepp INTERFACE "${bdsg_DIR}/deps/sparsepp/")
 add_subdirectory("${bdsg_DIR}/deps/mio")
 
 if (BUILD_PYTHON_BINDINGS)
+
     # Binder (because some generated bindings depend on headers packaged with Binder)
+    # See also: Binder commit defined in make_and_run_binder.py which actually generates bindings.
+    set(BINDER_COMMIT a1f81c86b75075aea2a7aab2c02f45f95fd5fe84)
     ExternalProject_Add(binder
-      GIT_REPOSITORY "https://github.com/RosettaCommons/binder.git"
-      GIT_TAG "ee2ecff151d125c3add072a7765aebad6f42a70d"
+      GIT_REPOSITORY "https://github.com/adamnovak/binder.git"
+      GIT_TAG "${BINDER_COMMIT}"
       # we don't actually build or install Binder via its CMake because we just need its headers
       #CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR}
       CONFIGURE_COMMAND ""
@@ -202,6 +205,8 @@ if (BUILD_PYTHON_BINDINGS)
     set(binder_INCLUDE "${INSTALL_DIR}/${CMAKE_INSTALL_INCLUDEDIR}")
 
     # pybind11
+    # See also: pybind11 commit defined in make_and_run_binder.py.
+    set(PYBIND11_COMMIT 5b0a6fc2017fcc176545afe3e09c9f9885283242)
     if (CMAKE_MAJOR_VERSION EQUAL "3" AND CMAKE_MINOR_VERSION EQUAL "10")
         # We need pybind11 installed in ./pybind11 *before* CMake can finish processing this file.
         # On CMake 3.11+ we can do that with FetchContent
@@ -209,7 +214,7 @@ if (BUILD_PYTHON_BINDINGS)
         if (NOT EXISTS "${PROJECT_SOURCE_DIR}/pybind11")
             message(WARNING "Running on CMake without FetchContent_Declare; attempting to download pybind11 manually")
             execute_process(COMMAND git clone https://github.com/RosettaCommons/pybind11.git "${PROJECT_SOURCE_DIR}/pybind11")
-            execute_process(COMMAND git checkout 5b0a6fc2017fcc176545afe3e09c9f9885283242
+            execute_process(COMMAND git checkout "${PYBIND11_COMMIT}"
                             WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/pybind11")
         endif()
         
@@ -225,7 +230,7 @@ if (BUILD_PYTHON_BINDINGS)
         FetchContent_Declare(
             pybind11
             GIT_REPOSITORY https://github.com/RosettaCommons/pybind11.git
-            GIT_TAG 5b0a6fc2017fcc176545afe3e09c9f9885283242
+            GIT_TAG "${PYBIND11_COMMIT}"
         )
         FetchContent_GetProperties(pybind11)
         if (NOT pybind11_POPULATED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,7 +192,7 @@ if (BUILD_PYTHON_BINDINGS)
 
     # Binder (because some generated bindings depend on headers packaged with Binder)
     # See also: Binder commit defined in make_and_run_binder.py which actually generates bindings.
-    set(BINDER_COMMIT a1f81c86b75075aea2a7aab2c02f45f95fd5fe84)
+    set(BINDER_COMMIT d5ef611f80cc91848db1fbd09d26b97013aa4db5)
     ExternalProject_Add(binder
       GIT_REPOSITORY "https://github.com/adamnovak/binder.git"
       GIT_TAG "${BINDER_COMMIT}"

--- a/bdsg/include/bdsg/internal/binder_hook_bind.hpp
+++ b/bdsg/include/bdsg/internal/binder_hook_bind.hpp
@@ -4,6 +4,14 @@
 // Components needed at binding generation time to make pybind11/Binder work for the library.
 // Forced to be used as a source for things to bind, even though nothing includes it.
 
+// We need to include the OpenMP header with compiler attribute support
+// disabled, because Binder can't understand the malloc attribute used in GCC
+// 13's omp.h. See <https://github.com/llvm/llvm-project/issues/51607>.
+// Do this before anything else can use omp.h.
+#define __attribute__(...)
+#include <omp.h>
+#undef __attribute__
+
 #include <string.h>
 
 #include <vector>

--- a/make_and_run_binder.py
+++ b/make_and_run_binder.py
@@ -35,7 +35,7 @@ def clone_repos():
         parent = os.getcwd()
         os.chdir('binder')
         # See also: Binder commit defined in CMakeLists.txt for header files.
-        subprocess.check_call(['git', 'checkout', 'a1f81c86b75075aea2a7aab2c02f45f95fd5fe84'])
+        subprocess.check_call(['git', 'checkout', 'a270d8f8e8b2e0a9638bcf80b16e466e70ac8dc0'])
         os.chdir(parent)
     if not glob.glob("binder/build/pybind11"):
         print("pybind11 not found, cloning repo...")

--- a/make_and_run_binder.py
+++ b/make_and_run_binder.py
@@ -257,8 +257,8 @@ def make_bindings_code(all_includes_fn, binder_executable):
         compiler_version = int(subprocess.check_output(["gcc", "-dumpversion"]).decode('utf-8').split('.')[0])
         compiler_triple = subprocess.check_output(["gcc", "-dumpmachine"]).decode('utf-8').strip()
         command.append('-I' + f"/usr/lib/gcc/{compiler_triple}/{compiler_version}/include")
-        # TODO: It also can't *parse* the GCC13 omp.h once it finds it, due to https://github.com/llvm/llvm-project/issues/51607
-        # But it seems to generate bindings anyway?
+        # We rely on macro hacks in binder_hook_bind.hpp to translate the file
+        # into something Binder can understand.
 
     # Find Jansson
     jansson_flags = subprocess.check_output(['pkg-config', '--cflags', 'jansson']).decode('utf-8').strip().split(' ')

--- a/make_and_run_binder.py
+++ b/make_and_run_binder.py
@@ -35,7 +35,7 @@ def clone_repos():
         parent = os.getcwd()
         os.chdir('binder')
         # See also: Binder commit defined in CMakeLists.txt for header files.
-        subprocess.check_call(['git', 'checkout', 'd5ef611f80cc91848db1fbd09d26b97013aa4db5'])
+        subprocess.check_call(['git', 'checkout', 'b6cac94c78ade6c6ffcbda629ffa520561a31788'])
         os.chdir(parent)
     if not glob.glob("binder/build/pybind11"):
         print("pybind11 not found, cloning repo...")


### PR DESCRIPTION
This fixes bindings generation on GCC 13 on Ubuntu 24.04. It uses my patched version of Binder that is able to install a recent enough LLVM to understand (most of) the GCC 13 headers, and helps it out with finding OpenMP (at least where Ubuntu puts it).

It also works with Python 3.12.

See https://github.com/RosettaCommons/binder/pull/309 for the corresponding Binder PR.