### PR TITLE
Paths bug

### DIFF
--- a/bdsg/include/bdsg/overlays/packed_path_position_overlay.hpp
+++ b/bdsg/include/bdsg/overlays/packed_path_position_overlay.hpp
@@ -189,12 +189,24 @@ public:
     path_handle_t get_path_handle_of_step(const step_handle_t& step_handle) const;
     
 protected:
+
+
+    /// Execute a function on each path in the graph that matches the given sense, samples, and loci
+    bool for_each_path_matching_impl(const std::unordered_set<PathSense>* senses,
+                                     const std::unordered_set<std::string>* samples,
+                                     const std::unordered_set<std::string>* loci,
+                                     const std::function<bool(const path_handle_t&)>& iteratee) const;
+
     /// Execute a function on each path in the graph
     bool for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const;
     
     /// Calls the given function for each step of the given handle on a path.
     bool for_each_step_on_handle_impl(const handle_t& handle,
                                       const function<bool(const step_handle_t&)>& iteratee) const;
+
+    /// Calls the given function for each step of the given sense on the given handle on a path.
+    bool for_each_step_of_sense_impl(const handle_t& visited, const PathSense& sense, const std::function<bool(const step_handle_t&)>& iteratee) const;
+
     
 public:
     

--- a/bdsg/include/bdsg/overlays/path_position_overlays.hpp
+++ b/bdsg/include/bdsg/overlays/path_position_overlays.hpp
@@ -192,6 +192,9 @@ private:
     /// Calls the given function for each step of the given handle on a path.
     bool for_each_step_on_handle_impl(const handle_t& handle,
                                       const function<bool(const step_handle_t&)>& iteratee) const;
+
+    /// Calls the given function for each step of the given sense on the given handle on a path.
+    bool for_each_step_of_sense_impl(const handle_t& visited, const PathSense& sense, const std::function<bool(const step_handle_t&)>& iteratee) const;
     
 public:
     

--- a/bdsg/include/bdsg/overlays/path_position_overlays.hpp
+++ b/bdsg/include/bdsg/overlays/path_position_overlays.hpp
@@ -184,7 +184,7 @@ private:
     bool for_each_path_matching_impl(const std::unordered_set<PathSense>* senses,
                                      const std::unordered_set<std::string>* samples,
                                      const std::unordered_set<std::string>* loci,
-                                     const std::function<bool(const path_handle_t&)>& iteratee) const
+                                     const std::function<bool(const path_handle_t&)>& iteratee) const;
 
     /// Execute a function on each path in the graph
     bool for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const;

--- a/bdsg/include/bdsg/overlays/path_position_overlays.hpp
+++ b/bdsg/include/bdsg/overlays/path_position_overlays.hpp
@@ -179,6 +179,13 @@ public:
     path_handle_t get_path_handle_of_step(const step_handle_t& step_handle) const;
     
 private:
+
+    /// Execute a function on each path in the graph that match the given senses, samples, and loci
+    bool for_each_path_matching_impl(const std::unordered_set<PathSense>* senses,
+                                     const std::unordered_set<std::string>* samples,
+                                     const std::unordered_set<std::string>* loci,
+                                     const std::function<bool(const path_handle_t&)>& iteratee) const
+
     /// Execute a function on each path in the graph
     bool for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const;
     

--- a/bdsg/src/packed_path_position_overlay.cpp
+++ b/bdsg/src/packed_path_position_overlay.cpp
@@ -229,7 +229,7 @@ void PackedPositionOverlay::index_path_positions() {
     // locals. So first we'll collect all the path handles.
     // TODO: deduplicate with BBHashHelper's copy of all the path handles?
     std::vector<path_handle_t> path_handles;
-    for_each_path_matching(nullptr, nullptr, nullptr, [&](const path_handle_t& path_handle) {
+    for_each_path_handle([&](const path_handle_t& path_handle) {
         path_handles.push_back(path_handle);
     });
     

--- a/bdsg/src/packed_path_position_overlay.cpp
+++ b/bdsg/src/packed_path_position_overlay.cpp
@@ -143,10 +143,23 @@ bool PackedPositionOverlay::for_each_path_handle_impl(const std::function<bool(c
     return graph->for_each_path_handle(iteratee);
 }
 
+bool PackedPositionOverlay::for_each_path_matching_impl(const std::unordered_set<PathSense>* senses,
+                                                  const std::unordered_set<std::string>* samples,
+                                                  const std::unordered_set<std::string>* loci,
+                                                  const std::function<bool(const path_handle_t&)>& iteratee) const {
+    return graph->for_each_path_matching(senses, samples, loci, iteratee);
+}
+
 bool PackedPositionOverlay::for_each_step_on_handle_impl(const handle_t& handle,
                                                          const function<bool(const step_handle_t&)>& iteratee) const {
     return graph->for_each_step_on_handle(handle, iteratee);
 }
+
+bool PackedPositionOverlay::for_each_step_of_sense_impl(const handle_t& visited, const PathSense& sense,
+                                                  const std::function<bool(const step_handle_t&)>& iteratee) const {
+    return graph->for_each_step_of_sense(visited, sense, iteratee);
+}
+
 
 size_t PackedPositionOverlay::get_path_length(const path_handle_t& path_handle) const {
     const auto& range = path_range.at(as_integer(path_handle));

--- a/bdsg/src/packed_path_position_overlay.cpp
+++ b/bdsg/src/packed_path_position_overlay.cpp
@@ -3,7 +3,7 @@
 
 #include <omp.h> // BINDER_IGNORE because Binder can't find this
 
-#define debug
+//#define debug
 
 namespace bdsg {
 

--- a/bdsg/src/packed_path_position_overlay.cpp
+++ b/bdsg/src/packed_path_position_overlay.cpp
@@ -3,7 +3,7 @@
 
 #include <omp.h> // BINDER_IGNORE because Binder can't find this
 
-//#define debug
+#define debug
 
 namespace bdsg {
 
@@ -229,7 +229,7 @@ void PackedPositionOverlay::index_path_positions() {
     // locals. So first we'll collect all the path handles.
     // TODO: deduplicate with BBHashHelper's copy of all the path handles?
     std::vector<path_handle_t> path_handles;
-    for_each_path_handle([&](const path_handle_t& path_handle) {
+    for_each_path_matching(nullptr, nullptr, nullptr, [&](const path_handle_t& path_handle) {
         path_handles.push_back(path_handle);
     });
     

--- a/bdsg/src/path_position_overlays.cpp
+++ b/bdsg/src/path_position_overlays.cpp
@@ -145,6 +145,13 @@ namespace bdsg {
     bool PositionOverlay::for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const {
         return get_graph()->for_each_path_handle(iteratee);
     }
+
+    bool PositionOverlay::for_each_path_matching_impl(const std::unordered_set<PathSense>* senses,
+                                                      const std::unordered_set<std::string>* samples,
+                                                      const std::unordered_set<std::string>* loci,
+                                                      const std::function<bool(const path_handle_t&)>& iteratee) const {
+        return get_graph()->for_each_path_matching(senses, samples, loci, iteratee);
+    }
     
     bool PositionOverlay::for_each_step_on_handle_impl(const handle_t& handle,
                                                        const function<bool(const step_handle_t&)>& iteratee) const {

--- a/bdsg/src/path_position_overlays.cpp
+++ b/bdsg/src/path_position_overlays.cpp
@@ -157,6 +157,10 @@ namespace bdsg {
                                                        const function<bool(const step_handle_t&)>& iteratee) const {
         return get_graph()->for_each_step_on_handle(handle, iteratee);
     }
+
+    bool PositionOverlay::for_each_step_of_sense_impl(const handle_t& visited, const PathSense& sense, const std::function<bool(const step_handle_t&)>& iteratee) const {
+        return get_graph()->for_each_step_of_sense(visited, sense, iteratee);
+    }
     
     size_t PositionOverlay::get_path_length(const path_handle_t& path_handle) const {
         const auto& path_step_by_position = step_by_position.at(path_handle);

--- a/bdsg/src/path_position_overlays.cpp
+++ b/bdsg/src/path_position_overlays.cpp
@@ -158,7 +158,8 @@ namespace bdsg {
         return get_graph()->for_each_step_on_handle(handle, iteratee);
     }
 
-    bool PositionOverlay::for_each_step_of_sense_impl(const handle_t& visited, const PathSense& sense, const std::function<bool(const step_handle_t&)>& iteratee) const {
+    bool PositionOverlay::for_each_step_of_sense_impl(const handle_t& visited, const PathSense& sense, 
+                                                      const std::function<bool(const step_handle_t&)>& iteratee) const {
         return get_graph()->for_each_step_of_sense(visited, sense, iteratee);
     }
     


### PR DESCRIPTION
I was having a problem where I used an overlay to get a `PathPositionHandleGraph`, and the graph would call `PathMetadata::for_each_path_matching_impl` instead of `GBWTGraph::for_each_path_matching_impl` (for example). 

I tried to fix it  [here](https://github.com/vgteam/libhandlegraph/pull/101) I think this does it properly by having the PackedPositionOverlay and PathPositionOverlay implement their own version of `for_each_path_matching_impl` that calls the graph's version of the method, instead of defaulting to `PathMetadata`'s versions.