### PR TITLE
Check if handlegraph_objs already exists before building it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,10 +175,16 @@ target_link_libraries(dynamic INTERFACE tsl::hopscotch_map)
 
 # libhandlegraph (full build using its cmake config)
 # Produces handlegraph_shared and handlegraph_static targets (as well as handlegraph_objs)
-if (NOT TARGET handlegraph_objs)
-    # If handlegraph has not already been built by something else
+find_package(libhandlegraph)
+if (${libhandlegraph_FOUND})
+    message("Using installed libhandlegraph")
+elseif (NOT TARGET handlegraph_objs)
+    message("Using bundled libhandlegraph")
     add_subdirectory("${bdsg_DIR}/deps/libhandlegraph")
+else ()
+    message("Using libhandlegraph built by someone else")
 endif()
+
 
 # BBHash perfect hasher (header only)
 # Does not ship its own install step or define a target, so we make our own target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,10 @@ target_link_libraries(dynamic INTERFACE tsl::hopscotch_map)
 
 # libhandlegraph (full build using its cmake config)
 # Produces handlegraph_shared and handlegraph_static targets (as well as handlegraph_objs)
-add_subdirectory("${bdsg_DIR}/deps/libhandlegraph")
+if (NOT TARGET handlegraph_objs)
+    # If handlegraph has not already been built by something else
+    add_subdirectory("${bdsg_DIR}/deps/libhandlegraph")
+endif()
 
 # BBHash perfect hasher (header only)
 # Does not ship its own install step or define a target, so we make our own target


### PR DESCRIPTION
I was having trouble building a Cmake project using `libbdsg` and `libvgio` because both depended on `libhandlegraph`. 

```
CMake Error at deps/libvgio/deps/libhandlegraph/CMakeLists.txt:37 (add_library):
  add_library cannot create target "handlegraph_objs" because another target
  with the same name already exists.  The existing target is created in
  source directory
  "/home/xhchang/GitHub/STOAT/deps/libbdsg/bdsg/deps/libhandlegraph".  See
  documentation for policy CMP0002 for more details.


CMake Error at deps/libvgio/deps/libhandlegraph/CMakeLists.txt:116 (add_library):
  add_library cannot create target "handlegraph_shared" because another
  target with the same name already exists.  The existing target is a shared
  library created in source directory
  "/home/xhchang/GitHub/STOAT/deps/libbdsg/bdsg/deps/libhandlegraph".  See
  documentation for policy CMP0002 for more details.


CMake Error at deps/libvgio/deps/libhandlegraph/CMakeLists.txt:119 (add_library):
  add_library cannot create target "handlegraph_static" because another
  target with the same name already exists.  The existing target is a static
  library created in source directory
  "/home/xhchang/GitHub/STOAT/deps/libbdsg/bdsg/deps/libhandlegraph".  See
  documentation for policy CMP0002 for more details.
```

I fixed this by checking if `handlegraph_objs` already exists before re-building it