### PR TITLE
Save orientations of tips in tippy_child_ranks

### DIFF
--- a/bdsg/include/bdsg/snarl_distance_index.hpp
+++ b/bdsg/include/bdsg/snarl_distance_index.hpp
@@ -199,6 +199,8 @@ public:
     void serialize_members(std::ostream& out) const;
     void deserialize_members(std::istream& in);
 
+    /// Call when loading a distance index; will error if wrong version
+    void check_version_on_load() const;
 
     virtual uint32_t get_magic_number() const;
     std::string get_prefix() const;
@@ -825,7 +827,7 @@ private:
     // that start with component count
     const static size_t CURRENT_VERSION_NUMBER = 4;
     // A verion to allow though but warn about
-    const static size_t WARN_VERSION_NUMBER = 4;
+    const static size_t WARN_VERSION_NUMBER = 3;
     /// Arbitrary large number which doens't overflow the number of bits we give
     const static size_t VERSION_NUMBER_SENTINEL = (1 << 10) - 1;
 

--- a/bdsg/include/bdsg/snarl_distance_index.hpp
+++ b/bdsg/include/bdsg/snarl_distance_index.hpp
@@ -824,6 +824,8 @@ private:
     // to avoid getting confused with old indexes without version numbers
     // that start with component count
     const static size_t CURRENT_VERSION_NUMBER = 4;
+    // A verion to allow though but warn about
+    const static size_t WARN_VERSION_NUMBER = 4;
     /// Arbitrary large number which doens't overflow the number of bits we give
     const static size_t VERSION_NUMBER_SENTINEL = (1 << 10) - 1;
 

--- a/bdsg/include/bdsg/snarl_distance_index.hpp
+++ b/bdsg/include/bdsg/snarl_distance_index.hpp
@@ -820,10 +820,10 @@ private:
     const static size_t MIN_NODE_ID_OFFSET = 4;
     const static size_t MAX_TREE_DEPTH_OFFSET = 5;
 
-    // While the version number is 3, store it in a bit masked way
+    // While the version number is 4, store it in a bit masked way
     // to avoid getting confused with old indexes without version numbers
     // that start with component count
-    const static size_t CURRENT_VERSION_NUMBER = 3;
+    const static size_t CURRENT_VERSION_NUMBER = 4;
     /// Arbitrary large number which doens't overflow the number of bits we give
     const static size_t VERSION_NUMBER_SENTINEL = (1 << 10) - 1;
 

--- a/bdsg/include/bdsg/snarl_distance_index.hpp
+++ b/bdsg/include/bdsg/snarl_distance_index.hpp
@@ -1644,8 +1644,10 @@ public:
             bool is_tip = false;
             bool is_root_snarl = false;
             bool include_distances = true;
-            vector<pair<temp_record_t, size_t>> children; //All children, nodes and chains, in arbitrary order
-            unordered_set<size_t> tippy_child_ranks; //The ranks of children that are tips
+            //All children, nodes and chains, in arbitrary order
+            vector<pair<temp_record_t, size_t>> children; 
+            //The ranks & orientations of children that are tips
+            unordered_map<size_t, bool> tippy_child_ranks; 
             //vector<tuple<pair<size_t, bool>, pair<size_t, bool>, size_t>> distances;
             unordered_map<pair<pair<size_t, bool>, pair<size_t, bool>>, size_t> distances;
                      

--- a/bdsg/src/snarl_distance_index.cpp
+++ b/bdsg/src/snarl_distance_index.cpp
@@ -1068,8 +1068,15 @@ void SnarlDistanceIndex::deserialize(int fd) {
     snarl_tree_records.load(fd, get_prefix());
     RootRecord root_record (get_root(), &snarl_tree_records);
     if (root_record.get_version_number() != CURRENT_VERSION_NUMBER) {
-        throw runtime_error("error: Trying to load a SnarlDistanceIndex which is not version " +
-                            std::to_string(CURRENT_VERSION_NUMBER) + "; try regenerating the index");
+        if (root_record.get_version_number() == WARN_VERSION_NUMBER) {
+            cerr << "WARNING: loading in a SnarlDistanceIndex which is v" << WARN_VERSION_NUMBER
+                 << " instead of the up-to-date v" << CURRENT_VERSION_NUMBER << endl;
+            cerr << "Upgrading to the latest version will improve alignments from vg giraffe's chaining mode " << endl
+                 << "(i.e. if long-read alignment from hifi, r10, or also sr-chaining)" << endl;
+        } else {
+            throw runtime_error("error: Trying to load a SnarlDistanceIndex which is not version " +
+                                std::to_string(CURRENT_VERSION_NUMBER) + "; try regenerating the index");
+        }
     }
 }
 

--- a/bdsg/src/snarl_distance_index.cpp
+++ b/bdsg/src/snarl_distance_index.cpp
@@ -1066,18 +1066,7 @@ void SnarlDistanceIndex::deserialize(int fd) {
     //This gets called by TriviallySerializable::deserialize(filename), which
     //doesn't check for the prefix, so this should expect it
     snarl_tree_records.load(fd, get_prefix());
-    RootRecord root_record (get_root(), &snarl_tree_records);
-    if (root_record.get_version_number() != CURRENT_VERSION_NUMBER) {
-        if (root_record.get_version_number() == WARN_VERSION_NUMBER) {
-            cerr << "WARNING: loading in a SnarlDistanceIndex which is v" << WARN_VERSION_NUMBER
-                 << " instead of the up-to-date v" << CURRENT_VERSION_NUMBER << endl;
-            cerr << "Upgrading to the latest version will improve alignments from vg giraffe's chaining mode " << endl
-                 << "(i.e. if long-read alignment from hifi, r10, or also sr-chaining)" << endl;
-        } else {
-            throw runtime_error("error: Trying to load a SnarlDistanceIndex which is not version " +
-                                std::to_string(CURRENT_VERSION_NUMBER) + "; try regenerating the index");
-        }
-    }
+    check_version_on_load();
 }
 
 void SnarlDistanceIndex::serialize_members(std::ostream& out) const {
@@ -1089,10 +1078,22 @@ void SnarlDistanceIndex::deserialize_members(std::istream& in){
     //This gets called by Serializable::deserialize(istream), which has already
     //read the prefix, so don't expect the prefix
     snarl_tree_records.load_after_prefix(in, get_prefix());
+    check_version_on_load();
+}
+
+void SnarlDistanceIndex::check_version_on_load() const {
     RootRecord root_record (get_root(), &snarl_tree_records);
     if (root_record.get_version_number() != CURRENT_VERSION_NUMBER) {
-        throw runtime_error("error: Trying to load a SnarlDistanceIndex which is not version " +
-                            std::to_string(CURRENT_VERSION_NUMBER) + "; try regenerating the index");
+        if (root_record.get_version_number() == WARN_VERSION_NUMBER) {
+            cerr << "WARNING: loading in a SnarlDistanceIndex which is v" << WARN_VERSION_NUMBER
+                 << " instead of the up-to-date v" << CURRENT_VERSION_NUMBER << endl;
+            cerr << "Upgrading to the latest version will improve alignments from vg giraffe's chaining mode " << endl
+                 << "(i.e. if long-read alignment from hifi, r10, or also sr-chaining)" << endl;
+        } else {
+            throw runtime_error("error: Trying to load a SnarlDistanceIndex which is v" +
+                                std::to_string(root_record.get_version_number()) + " instead of the up-to-date v" +
+                                std::to_string(CURRENT_VERSION_NUMBER) + "; try regenerating the index");
+        }
     }
 }
 


### PR DESCRIPTION
I needed to know which end of the child tip was the tip end (i.e. has no edges) so I added a field to `tippy_child_ranks`. Barely affects anything since those data weren't really used.