### PR TITLE
Make position indexing work more similarly across implementations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,10 @@ OPTION(USE_INSTALLED_LIBHANDLEGRAPH "Use the version of libhandlegraph installed
 # TODO: We can only do out-of-source builds!
 # TODO: How do we error out meaningfully on in-source builds?
 
-# We build using c++14
-set(CMAKE_CXX_STANDARD 14)
+# We build using c++17
+# See also: standard in make_and_run_binder.py
+# See also: standard in Makefile
+set(CMAKE_CXX_STANDARD 17)
 # We need library paths to be relative in the build directories so we can let
 # the libraries in our Python module find each other when we package them into
 # a wheel. This only works on CMake 3.14+; older CMake we have to bully with
@@ -207,7 +209,7 @@ if (BUILD_PYTHON_BINDINGS)
 
     # Binder (because some generated bindings depend on headers packaged with Binder)
     # See also: Binder commit defined in make_and_run_binder.py which actually generates bindings.
-    set(BINDER_COMMIT 46ec0e88137d368eeedafecfa123004f8ad028d1)
+    set(BINDER_COMMIT 93efb505172ce0ef34faa1f69a8e8f2b7455ce18)
     ExternalProject_Add(binder
       GIT_REPOSITORY "https://github.com/RosettaCommons/binder.git"
       GIT_TAG "${BINDER_COMMIT}"

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,9 @@ OBJS += $(OBJ_DIR)/snarl_distance_index.o
 OBJS += $(OBJ_DIR)/strand_split_overlay.o 
 OBJS += $(OBJ_DIR)/utility.o
 
-CXXFLAGS :=-MMD -MP -O3 -Werror=return-type -std=c++14 -ggdb -g -I$(INC_DIR) $(CXXFLAGS)
+# See also: standard in CMakeLists.txt
+# # See also: standard in make_and_run_binder.py
+CXXFLAGS :=-MMD -MP -O3 -Werror=return-type -std=c++17 -ggdb -g -I$(INC_DIR) $(CXXFLAGS)
 
 ifeq ($(shell uname -s),Darwin)
 	CXXFLAGS := $(CXXFLAGS) -Xpreprocessor -fopenmp

--- a/bdsg/cmake_bindings/bdsg/graph_proxy.cpp
+++ b/bdsg/cmake_bindings/bdsg/graph_proxy.cpp
@@ -1,3 +1,4 @@
+#include <__ostream/basic_ostream.h>
 #include <bdsg/graph_proxy.hpp>
 #include <bdsg/internal/base_packed_graph.hpp>
 #include <bdsg/internal/graph_proxy_handle_graph_fragment.classfragment>
@@ -9,12 +10,11 @@
 #include <handlegraph/types.hpp>
 #include <ios>
 #include <istream>
-#include <iterator>
 #include <memory>
-#include <ostream>
 #include <sstream> // __str__
 #include <streambuf>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <utility>
 #include <vector>

--- a/bdsg/cmake_bindings/bdsg/graph_proxy_1.cpp
+++ b/bdsg/cmake_bindings/bdsg/graph_proxy_1.cpp
@@ -1,3 +1,4 @@
+#include <__ostream/basic_ostream.h>
 #include <bdsg/graph_proxy.hpp>
 #include <bdsg/internal/base_packed_graph.hpp>
 #include <bdsg/internal/graph_proxy_handle_graph_fragment.classfragment>
@@ -9,12 +10,11 @@
 #include <handlegraph/types.hpp>
 #include <ios>
 #include <istream>
-#include <iterator>
 #include <memory>
-#include <ostream>
 #include <sstream> // __str__
 #include <streambuf>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 

--- a/bdsg/cmake_bindings/bdsg/internal/base_packed_graph.cpp
+++ b/bdsg/cmake_bindings/bdsg/internal/base_packed_graph.cpp
@@ -1,15 +1,15 @@
+#include <__ostream/basic_ostream.h>
 #include <bdsg/internal/base_packed_graph.hpp>
 #include <bdsg/internal/mapped_structs.hpp>
 #include <functional>
 #include <handlegraph/types.hpp>
 #include <ios>
 #include <istream>
-#include <iterator>
 #include <memory>
-#include <ostream>
 #include <sstream> // __str__
 #include <streambuf>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>

--- a/bdsg/cmake_bindings/bdsg/internal/eades_algorithm.cpp
+++ b/bdsg/cmake_bindings/bdsg/internal/eades_algorithm.cpp
@@ -2,9 +2,9 @@
 #include <functional>
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/types.hpp>
-#include <iterator>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 

--- a/bdsg/cmake_bindings/bdsg/internal/hash_map.cpp
+++ b/bdsg/cmake_bindings/bdsg/internal/hash_map.cpp
@@ -13,11 +13,11 @@
 #include <handlegraph/types.hpp>
 #include <ios>
 #include <istream>
-#include <iterator>
 #include <memory>
 #include <sstream> // __str__
 #include <streambuf>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -1040,11 +1040,6 @@ void bind_bdsg_internal_hash_map(std::function< pybind11::module &(std::string c
 		pybind11::class_<bdsg::wang_hash<long long,void>, std::shared_ptr<bdsg::wang_hash<long long,void>>> cl(M("bdsg"), "wang_hash_long_long_void_t", "");
 		cl.def( pybind11::init( [](){ return new bdsg::wang_hash<long long,void>(); } ) );
 		cl.def("__call__", (unsigned long (bdsg::wang_hash<long long,void>::*)(const long long &) const) &bdsg::wang_hash<long long>::operator(), "C++: bdsg::wang_hash<long long>::operator()(const long long &) const --> unsigned long", pybind11::arg("x"));
-	}
-	{ // bdsg::wang_hash file:bdsg/internal/hash_map.hpp line:120
-		pybind11::class_<bdsg::wang_hash<long,void>, std::shared_ptr<bdsg::wang_hash<long,void>>> cl(M("bdsg"), "wang_hash_long_void_t", "");
-		cl.def( pybind11::init( [](){ return new bdsg::wang_hash<long,void>(); } ) );
-		cl.def("__call__", (unsigned long (bdsg::wang_hash<long,void>::*)(const long &) const) &bdsg::wang_hash<long>::operator(), "C++: bdsg::wang_hash<long>::operator()(const long &) const --> unsigned long", pybind11::arg("x"));
 	}
 	{ // bdsg::wang_hash file:bdsg/internal/hash_map.hpp line:120
 		pybind11::class_<bdsg::wang_hash<char,void>, std::shared_ptr<bdsg::wang_hash<char,void>>> cl(M("bdsg"), "wang_hash_char_void_t", "");

--- a/bdsg/cmake_bindings/bdsg/internal/is_single_stranded.cpp
+++ b/bdsg/cmake_bindings/bdsg/internal/is_single_stranded.cpp
@@ -2,9 +2,9 @@
 #include <functional>
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/types.hpp>
-#include <iterator>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 

--- a/bdsg/cmake_bindings/bdsg/internal/mapped_structs_1.cpp
+++ b/bdsg/cmake_bindings/bdsg/internal/mapped_structs_1.cpp
@@ -1,8 +1,8 @@
+#include <__ostream/basic_ostream.h>
 #include <bdsg/internal/mapped_structs.hpp>
 #include <bdsg/internal/packed_structs.hpp>
 #include <ios>
 #include <istream>
-#include <ostream>
 #include <sstream> // __str__
 #include <streambuf>
 #include <string>
@@ -50,15 +50,17 @@ void bind_bdsg_internal_mapped_structs_1(std::function< pybind11::module &(std::
 		pybind11::class_<bdsg::IntVectorFor<bdsg::CompatBackend>, std::shared_ptr<bdsg::IntVectorFor<bdsg::CompatBackend>>> cl(M("bdsg"), "IntVectorFor_bdsg_CompatBackend_t", "");
 		cl.def( pybind11::init( [](){ return new bdsg::IntVectorFor<bdsg::CompatBackend>(); } ) );
 	}
-	{ // bdsg::PackedDeque file:bdsg/internal/packed_structs.hpp line:327
+	{ // bdsg::PackedDeque file:bdsg/internal/packed_structs.hpp line:491
 		pybind11::class_<bdsg::PackedDeque<bdsg::STLBackend>, std::shared_ptr<bdsg::PackedDeque<bdsg::STLBackend>>> cl(M("bdsg"), "PackedDeque_bdsg_STLBackend_t", "");
 		cl.def( pybind11::init( [](){ return new bdsg::PackedDeque<bdsg::STLBackend>(); } ) );
 		cl.def( pybind11::init( [](bdsg::PackedDeque<bdsg::STLBackend> const &o){ return new bdsg::PackedDeque<bdsg::STLBackend>(o); } ) );
 		cl.def("assign", (class bdsg::PackedDeque<> & (bdsg::PackedDeque<bdsg::STLBackend>::*)(const class bdsg::PackedDeque<> &)) &bdsg::PackedDeque<>::operator=, "C++: bdsg::PackedDeque<>::operator=(const class bdsg::PackedDeque<> &) --> class bdsg::PackedDeque<> &", pybind11::return_value_policy::automatic, pybind11::arg("other"));
-		cl.def("set", (void (bdsg::PackedDeque<bdsg::STLBackend>::*)(const unsigned long &, const unsigned long &)) &bdsg::PackedDeque<>::set, "C++: bdsg::PackedDeque<>::set(const unsigned long &, const unsigned long &) --> void", pybind11::arg("i"), pybind11::arg("value"));
-		cl.def("get", (unsigned long (bdsg::PackedDeque<bdsg::STLBackend>::*)(const unsigned long &) const) &bdsg::PackedDeque<>::get, "C++: bdsg::PackedDeque<>::get(const unsigned long &) const --> unsigned long", pybind11::arg("i"));
-		cl.def("push_front", (void (bdsg::PackedDeque<bdsg::STLBackend>::*)(const unsigned long &)) &bdsg::PackedDeque<>::push_front, "C++: bdsg::PackedDeque<>::push_front(const unsigned long &) --> void", pybind11::arg("value"));
-		cl.def("push_back", (void (bdsg::PackedDeque<bdsg::STLBackend>::*)(const unsigned long &)) &bdsg::PackedDeque<>::push_back, "C++: bdsg::PackedDeque<>::push_back(const unsigned long &) --> void", pybind11::arg("value"));
+		cl.def("set", (void (bdsg::PackedDeque<bdsg::STLBackend>::*)(const unsigned long &, const unsigned long long &)) &bdsg::PackedDeque<>::set, "C++: bdsg::PackedDeque<>::set(const unsigned long &, const unsigned long long &) --> void", pybind11::arg("i"), pybind11::arg("value"));
+		cl.def("get", (unsigned long long (bdsg::PackedDeque<bdsg::STLBackend>::*)(const unsigned long &) const) &bdsg::PackedDeque<>::get, "C++: bdsg::PackedDeque<>::get(const unsigned long &) const --> unsigned long long", pybind11::arg("i"));
+		cl.def("push_front", (void (bdsg::PackedDeque<bdsg::STLBackend>::*)(const unsigned long long &)) &bdsg::PackedDeque<>::push_front, "C++: bdsg::PackedDeque<>::push_front(const unsigned long long &) --> void", pybind11::arg("value"));
+		cl.def("append_front", (void (bdsg::PackedDeque<bdsg::STLBackend>::*)(const unsigned long long &)) &bdsg::PackedDeque<>::append_front, "C++: bdsg::PackedDeque<>::append_front(const unsigned long long &) --> void", pybind11::arg("value"));
+		cl.def("push_back", (void (bdsg::PackedDeque<bdsg::STLBackend>::*)(const unsigned long long &)) &bdsg::PackedDeque<>::push_back, "C++: bdsg::PackedDeque<>::push_back(const unsigned long long &) --> void", pybind11::arg("value"));
+		cl.def("append_back", (void (bdsg::PackedDeque<bdsg::STLBackend>::*)(const unsigned long long &)) &bdsg::PackedDeque<>::append_back, "C++: bdsg::PackedDeque<>::append_back(const unsigned long long &) --> void", pybind11::arg("value"));
 		cl.def("pop_front", (void (bdsg::PackedDeque<bdsg::STLBackend>::*)()) &bdsg::PackedDeque<>::pop_front, "C++: bdsg::PackedDeque<>::pop_front() --> void");
 		cl.def("pop_back", (void (bdsg::PackedDeque<bdsg::STLBackend>::*)()) &bdsg::PackedDeque<>::pop_back, "C++: bdsg::PackedDeque<>::pop_back() --> void");
 		cl.def("reserve", (void (bdsg::PackedDeque<bdsg::STLBackend>::*)(const unsigned long &)) &bdsg::PackedDeque<>::reserve, "C++: bdsg::PackedDeque<>::reserve(const unsigned long &) --> void", pybind11::arg("future_size"));
@@ -67,14 +69,14 @@ void bind_bdsg_internal_mapped_structs_1(std::function< pybind11::module &(std::
 		cl.def("clear", (void (bdsg::PackedDeque<bdsg::STLBackend>::*)()) &bdsg::PackedDeque<>::clear, "C++: bdsg::PackedDeque<>::clear() --> void");
 		cl.def("memory_usage", (unsigned long (bdsg::PackedDeque<bdsg::STLBackend>::*)() const) &bdsg::PackedDeque<>::memory_usage, "C++: bdsg::PackedDeque<>::memory_usage() const --> unsigned long");
 	}
-	{ // bdsg::PackedSet file:bdsg/internal/packed_structs.hpp line:411
+	{ // bdsg::PackedSet file:bdsg/internal/packed_structs.hpp line:597
 		pybind11::class_<bdsg::PackedSet<bdsg::STLBackend>, std::shared_ptr<bdsg::PackedSet<bdsg::STLBackend>>> cl(M("bdsg"), "PackedSet_bdsg_STLBackend_t", "");
 		cl.def( pybind11::init( [](){ return new bdsg::PackedSet<bdsg::STLBackend>(); } ) );
 		cl.def( pybind11::init( [](bdsg::PackedSet<bdsg::STLBackend> const &o){ return new bdsg::PackedSet<bdsg::STLBackend>(o); } ) );
 		cl.def("assign", (class bdsg::PackedSet<> & (bdsg::PackedSet<bdsg::STLBackend>::*)(const class bdsg::PackedSet<> &)) &bdsg::PackedSet<>::operator=, "C++: bdsg::PackedSet<>::operator=(const class bdsg::PackedSet<> &) --> class bdsg::PackedSet<> &", pybind11::return_value_policy::automatic, pybind11::arg("other"));
-		cl.def("insert", (void (bdsg::PackedSet<bdsg::STLBackend>::*)(const unsigned long &)) &bdsg::PackedSet<>::insert, "C++: bdsg::PackedSet<>::insert(const unsigned long &) --> void", pybind11::arg("value"));
-		cl.def("find", (bool (bdsg::PackedSet<bdsg::STLBackend>::*)(const unsigned long &) const) &bdsg::PackedSet<>::find, "C++: bdsg::PackedSet<>::find(const unsigned long &) const --> bool", pybind11::arg("value"));
-		cl.def("remove", (void (bdsg::PackedSet<bdsg::STLBackend>::*)(const unsigned long &)) &bdsg::PackedSet<>::remove, "C++: bdsg::PackedSet<>::remove(const unsigned long &) --> void", pybind11::arg("value"));
+		cl.def("insert", (void (bdsg::PackedSet<bdsg::STLBackend>::*)(const unsigned long long &)) &bdsg::PackedSet<>::insert, "C++: bdsg::PackedSet<>::insert(const unsigned long long &) --> void", pybind11::arg("value"));
+		cl.def("find", (bool (bdsg::PackedSet<bdsg::STLBackend>::*)(const unsigned long long &) const) &bdsg::PackedSet<>::find, "C++: bdsg::PackedSet<>::find(const unsigned long long &) const --> bool", pybind11::arg("value"));
+		cl.def("remove", (void (bdsg::PackedSet<bdsg::STLBackend>::*)(const unsigned long long &)) &bdsg::PackedSet<>::remove, "C++: bdsg::PackedSet<>::remove(const unsigned long long &) --> void", pybind11::arg("value"));
 		cl.def("size", (unsigned long (bdsg::PackedSet<bdsg::STLBackend>::*)() const) &bdsg::PackedSet<>::size, "C++: bdsg::PackedSet<>::size() const --> unsigned long");
 		cl.def("empty", (bool (bdsg::PackedSet<bdsg::STLBackend>::*)() const) &bdsg::PackedSet<>::empty, "C++: bdsg::PackedSet<>::empty() const --> bool");
 		cl.def("set_load_factors", (void (bdsg::PackedSet<bdsg::STLBackend>::*)(double, double)) &bdsg::PackedSet<>::set_load_factors, "C++: bdsg::PackedSet<>::set_load_factors(double, double) --> void", pybind11::arg("min_load_factor"), pybind11::arg("max_load_factor"));

--- a/bdsg/cmake_bindings/bdsg/overlays/packed_path_position_overlay.cpp
+++ b/bdsg/cmake_bindings/bdsg/overlays/packed_path_position_overlay.cpp
@@ -5,10 +5,10 @@
 #include <handlegraph/path_metadata.hpp>
 #include <handlegraph/path_position_handle_graph.hpp>
 #include <handlegraph/types.hpp>
-#include <iterator>
 #include <memory>
 #include <sstream> // __str__
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -31,7 +31,7 @@
 	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
 #endif
 
-// bdsg::PackedPositionOverlay file:bdsg/overlays/packed_path_position_overlay.hpp line:33
+// bdsg::PackedPositionOverlay file:bdsg/overlays/packed_path_position_overlay.hpp line:35
 struct PyCallBack_bdsg_PackedPositionOverlay : public bdsg::PackedPositionOverlay {
 	using bdsg::PackedPositionOverlay::PackedPositionOverlay;
 
@@ -729,7 +729,7 @@ struct PyCallBack_bdsg_PackedPositionOverlay : public bdsg::PackedPositionOverla
 
 void bind_bdsg_overlays_packed_path_position_overlay(std::function< pybind11::module &(std::string const &namespace_) > &M)
 {
-	{ // bdsg::PackedPositionOverlay file:bdsg/overlays/packed_path_position_overlay.hpp line:33
+	{ // bdsg::PackedPositionOverlay file:bdsg/overlays/packed_path_position_overlay.hpp line:35
 		pybind11::class_<bdsg::PackedPositionOverlay, std::shared_ptr<bdsg::PackedPositionOverlay>, PyCallBack_bdsg_PackedPositionOverlay, handlegraph::PathPositionHandleGraph, handlegraph::ExpandingOverlayGraph> cl(M("bdsg"), "PackedPositionOverlay", "");
 		cl.def( pybind11::init( [](PyCallBack_bdsg_PackedPositionOverlay const &o){ return new PyCallBack_bdsg_PackedPositionOverlay(o); } ) );
 		cl.def( pybind11::init( [](bdsg::PackedPositionOverlay const &o){ return new bdsg::PackedPositionOverlay(o); } ) );
@@ -770,7 +770,7 @@ void bind_bdsg_overlays_packed_path_position_overlay(std::function< pybind11::mo
 		cl.def("get_step_at_position", (struct handlegraph::step_handle_t (bdsg::PackedPositionOverlay::*)(const struct handlegraph::path_handle_t &, const unsigned long &) const) &bdsg::PackedPositionOverlay::get_step_at_position, "Returns the step at this position, measured in bases of sequence starting at\n the step returned by path_begin(). If the position is past the end of the\n path, returns path_end().\n\nC++: bdsg::PackedPositionOverlay::get_step_at_position(const struct handlegraph::path_handle_t &, const unsigned long &) const --> struct handlegraph::step_handle_t", pybind11::arg("path"), pybind11::arg("position"));
 		cl.def("get_underlying_handle", (struct handlegraph::handle_t (bdsg::PackedPositionOverlay::*)(const struct handlegraph::handle_t &) const) &bdsg::PackedPositionOverlay::get_underlying_handle, "Returns the handle in the underlying graph that corresponds to a handle in the\n overlay\n\nC++: bdsg::PackedPositionOverlay::get_underlying_handle(const struct handlegraph::handle_t &) const --> struct handlegraph::handle_t", pybind11::arg("handle"));
 	}
-	{ // bdsg::BBHashHelper file:bdsg/overlays/packed_path_position_overlay.hpp line:315
+	{ // bdsg::BBHashHelper file:bdsg/overlays/packed_path_position_overlay.hpp line:335
 		pybind11::class_<bdsg::BBHashHelper, std::shared_ptr<bdsg::BBHashHelper>> cl(M("bdsg"), "BBHashHelper", "");
 		cl.def( pybind11::init<const class handlegraph::PathHandleGraph *>(), pybind11::arg("graph") );
 
@@ -779,7 +779,7 @@ void bind_bdsg_overlays_packed_path_position_overlay(std::function< pybind11::mo
 		cl.def("end", (struct bdsg::BBHashHelper::iterator (bdsg::BBHashHelper::*)() const) &bdsg::BBHashHelper::end, "C++ style range end over steps\n\nC++: bdsg::BBHashHelper::end() const --> struct bdsg::BBHashHelper::iterator");
 		cl.def("assign", (struct bdsg::BBHashHelper & (bdsg::BBHashHelper::*)(const struct bdsg::BBHashHelper &)) &bdsg::BBHashHelper::operator=, "C++: bdsg::BBHashHelper::operator=(const struct bdsg::BBHashHelper &) --> struct bdsg::BBHashHelper &", pybind11::return_value_policy::automatic, pybind11::arg(""));
 
-		{ // bdsg::BBHashHelper::iterator file:bdsg/overlays/packed_path_position_overlay.hpp line:325
+		{ // bdsg::BBHashHelper::iterator file:bdsg/overlays/packed_path_position_overlay.hpp line:345
 			auto & enclosing_class = cl;
 			pybind11::class_<bdsg::BBHashHelper::iterator, std::shared_ptr<bdsg::BBHashHelper::iterator>> cl(enclosing_class, "iterator", "");
 			cl.def( pybind11::init( [](bdsg::BBHashHelper::iterator const &o){ return new bdsg::BBHashHelper::iterator(o); } ) );

--- a/bdsg/cmake_bindings/bdsg/overlays/packed_reference_path_overlay.cpp
+++ b/bdsg/cmake_bindings/bdsg/overlays/packed_reference_path_overlay.cpp
@@ -8,10 +8,10 @@
 #include <handlegraph/path_metadata.hpp>
 #include <handlegraph/path_position_handle_graph.hpp>
 #include <handlegraph/types.hpp>
-#include <iterator>
 #include <memory>
 #include <sstream> // __str__
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -34,7 +34,7 @@
 	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
 #endif
 
-// bdsg::PackedReferencePathOverlay file:bdsg/overlays/packed_reference_path_overlay.hpp line:33
+// bdsg::PackedReferencePathOverlay file:bdsg/overlays/packed_reference_path_overlay.hpp line:26
 struct PyCallBack_bdsg_PackedReferencePathOverlay : public bdsg::PackedReferencePathOverlay {
 	using bdsg::PackedReferencePathOverlay::PackedReferencePathOverlay;
 
@@ -50,6 +50,45 @@ struct PyCallBack_bdsg_PackedReferencePathOverlay : public bdsg::PackedReference
 			return pybind11::detail::cast_safe<struct handlegraph::path_handle_t>(std::move(o));
 		}
 		return PackedReferencePathOverlay::get_path_handle_of_step(a0);
+	}
+	bool has_path(const std::string & a0) const override {
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PackedReferencePathOverlay *>(this), "has_path");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<bool>::value) {
+				static pybind11::detail::override_caster_t<bool> caster;
+				return pybind11::detail::cast_ref<bool>(std::move(o), caster);
+			}
+			return pybind11::detail::cast_safe<bool>(std::move(o));
+		}
+		return PackedReferencePathOverlay::has_path(a0);
+	}
+	unsigned long get_path_count() const override {
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PackedReferencePathOverlay *>(this), "get_path_count");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>();
+			if (pybind11::detail::cast_is_temporary_value_reference<unsigned long>::value) {
+				static pybind11::detail::override_caster_t<unsigned long> caster;
+				return pybind11::detail::cast_ref<unsigned long>(std::move(o), caster);
+			}
+			return pybind11::detail::cast_safe<unsigned long>(std::move(o));
+		}
+		return PackedReferencePathOverlay::get_path_count();
+	}
+	bool for_each_path_handle_impl(const class std::function<bool (const struct handlegraph::path_handle_t &)> & a0) const override {
+		pybind11::gil_scoped_acquire gil;
+		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PackedReferencePathOverlay *>(this), "for_each_path_handle_impl");
+		if (overload) {
+			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
+			if (pybind11::detail::cast_is_temporary_value_reference<bool>::value) {
+				static pybind11::detail::override_caster_t<bool> caster;
+				return pybind11::detail::cast_ref<bool>(std::move(o), caster);
+			}
+			return pybind11::detail::cast_safe<bool>(std::move(o));
+		}
+		return PackedReferencePathOverlay::for_each_path_handle_impl(a0);
 	}
 	bool for_each_step_on_handle_impl(const struct handlegraph::handle_t & a0, const class std::function<bool (const struct handlegraph::step_handle_t &)> & a1) const override {
 		pybind11::gil_scoped_acquire gil;
@@ -272,32 +311,6 @@ struct PyCallBack_bdsg_PackedReferencePathOverlay : public bdsg::PackedReference
 		}
 		return PackedPositionOverlay::max_node_id();
 	}
-	unsigned long get_path_count() const override {
-		pybind11::gil_scoped_acquire gil;
-		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PackedReferencePathOverlay *>(this), "get_path_count");
-		if (overload) {
-			auto o = overload.operator()<pybind11::return_value_policy::reference>();
-			if (pybind11::detail::cast_is_temporary_value_reference<unsigned long>::value) {
-				static pybind11::detail::override_caster_t<unsigned long> caster;
-				return pybind11::detail::cast_ref<unsigned long>(std::move(o), caster);
-			}
-			return pybind11::detail::cast_safe<unsigned long>(std::move(o));
-		}
-		return PackedPositionOverlay::get_path_count();
-	}
-	bool has_path(const std::string & a0) const override {
-		pybind11::gil_scoped_acquire gil;
-		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PackedReferencePathOverlay *>(this), "has_path");
-		if (overload) {
-			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
-			if (pybind11::detail::cast_is_temporary_value_reference<bool>::value) {
-				static pybind11::detail::override_caster_t<bool> caster;
-				return pybind11::detail::cast_ref<bool>(std::move(o), caster);
-			}
-			return pybind11::detail::cast_safe<bool>(std::move(o));
-		}
-		return PackedPositionOverlay::has_path(a0);
-	}
 	struct handlegraph::path_handle_t get_path_handle(const std::string & a0) const override {
 		pybind11::gil_scoped_acquire gil;
 		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PackedReferencePathOverlay *>(this), "get_path_handle");
@@ -466,19 +479,6 @@ struct PyCallBack_bdsg_PackedReferencePathOverlay : public bdsg::PackedReference
 			return pybind11::detail::cast_safe<struct handlegraph::step_handle_t>(std::move(o));
 		}
 		return PackedPositionOverlay::get_previous_step(a0);
-	}
-	bool for_each_path_handle_impl(const class std::function<bool (const struct handlegraph::path_handle_t &)> & a0) const override {
-		pybind11::gil_scoped_acquire gil;
-		pybind11::function overload = pybind11::get_overload(static_cast<const bdsg::PackedReferencePathOverlay *>(this), "for_each_path_handle_impl");
-		if (overload) {
-			auto o = overload.operator()<pybind11::return_value_policy::reference>(a0);
-			if (pybind11::detail::cast_is_temporary_value_reference<bool>::value) {
-				static pybind11::detail::override_caster_t<bool> caster;
-				return pybind11::detail::cast_ref<bool>(std::move(o), caster);
-			}
-			return pybind11::detail::cast_safe<bool>(std::move(o));
-		}
-		return PackedPositionOverlay::for_each_path_handle_impl(a0);
 	}
 	bool for_each_step_of_sense_impl(const struct handlegraph::handle_t & a0, const enum handlegraph::PathSense & a1, const class std::function<bool (const struct handlegraph::step_handle_t &)> & a2) const override {
 		pybind11::gil_scoped_acquire gil;
@@ -983,7 +983,7 @@ struct PyCallBack_bdsg_PackedSubgraphOverlay : public bdsg::PackedSubgraphOverla
 	}
 };
 
-// bdsg::PositionOverlay file:bdsg/overlays/path_position_overlays.hpp line:30
+// bdsg::PositionOverlay file:bdsg/overlays/path_position_overlays.hpp line:32
 struct PyCallBack_bdsg_PositionOverlay : public bdsg::PositionOverlay {
 	using bdsg::PositionOverlay::PositionOverlay;
 
@@ -1655,11 +1655,13 @@ struct PyCallBack_bdsg_PositionOverlay : public bdsg::PositionOverlay {
 
 void bind_bdsg_overlays_packed_reference_path_overlay(std::function< pybind11::module &(std::string const &namespace_) > &M)
 {
-	{ // bdsg::PackedReferencePathOverlay file:bdsg/overlays/packed_reference_path_overlay.hpp line:33
+	{ // bdsg::PackedReferencePathOverlay file:bdsg/overlays/packed_reference_path_overlay.hpp line:26
 		pybind11::class_<bdsg::PackedReferencePathOverlay, std::shared_ptr<bdsg::PackedReferencePathOverlay>, PyCallBack_bdsg_PackedReferencePathOverlay, bdsg::PackedPositionOverlay> cl(M("bdsg"), "PackedReferencePathOverlay", "");
 		cl.def( pybind11::init( [](PyCallBack_bdsg_PackedReferencePathOverlay const &o){ return new PyCallBack_bdsg_PackedReferencePathOverlay(o); } ) );
 		cl.def( pybind11::init( [](bdsg::PackedReferencePathOverlay const &o){ return new bdsg::PackedReferencePathOverlay(o); } ) );
 		cl.def("get_path_handle_of_step", (struct handlegraph::path_handle_t (bdsg::PackedReferencePathOverlay::*)(const struct handlegraph::step_handle_t &) const) &bdsg::PackedReferencePathOverlay::get_path_handle_of_step, "overload this to use the cache \n\nC++: bdsg::PackedReferencePathOverlay::get_path_handle_of_step(const struct handlegraph::step_handle_t &) const --> struct handlegraph::path_handle_t", pybind11::arg("step_handle"));
+		cl.def("has_path", (bool (bdsg::PackedReferencePathOverlay::*)(const std::string &) const) &bdsg::PackedReferencePathOverlay::has_path, "Override to filter paths to those that are indexed. \n\nC++: bdsg::PackedReferencePathOverlay::has_path(const std::string &) const --> bool", pybind11::arg("path_name"));
+		cl.def("get_path_count", (unsigned long (bdsg::PackedReferencePathOverlay::*)() const) &bdsg::PackedReferencePathOverlay::get_path_count, "Override to filter paths to those that are indexed.\n\nC++: bdsg::PackedReferencePathOverlay::get_path_count() const --> unsigned long");
 		cl.def("assign", (class bdsg::PackedReferencePathOverlay & (bdsg::PackedReferencePathOverlay::*)(const class bdsg::PackedReferencePathOverlay &)) &bdsg::PackedReferencePathOverlay::operator=, "C++: bdsg::PackedReferencePathOverlay::operator=(const class bdsg::PackedReferencePathOverlay &) --> class bdsg::PackedReferencePathOverlay &", pybind11::return_value_policy::automatic, pybind11::arg(""));
 	}
 	{ // bdsg::PackedSubgraphOverlay file:bdsg/overlays/packed_subgraph_overlay.hpp line:27
@@ -1687,7 +1689,7 @@ void bind_bdsg_overlays_packed_reference_path_overlay(std::function< pybind11::m
 		cl.def("get_underlying_handle", (struct handlegraph::handle_t (bdsg::PackedSubgraphOverlay::*)(const struct handlegraph::handle_t &) const) &bdsg::PackedSubgraphOverlay::get_underlying_handle, "Returns the handle in the underlying graph that corresponds to a handle in the\n overlay\n\nC++: bdsg::PackedSubgraphOverlay::get_underlying_handle(const struct handlegraph::handle_t &) const --> struct handlegraph::handle_t", pybind11::arg("handle"));
 		cl.def("assign", (class bdsg::PackedSubgraphOverlay & (bdsg::PackedSubgraphOverlay::*)(const class bdsg::PackedSubgraphOverlay &)) &bdsg::PackedSubgraphOverlay::operator=, "C++: bdsg::PackedSubgraphOverlay::operator=(const class bdsg::PackedSubgraphOverlay &) --> class bdsg::PackedSubgraphOverlay &", pybind11::return_value_policy::automatic, pybind11::arg(""));
 	}
-	{ // bdsg::PositionOverlay file:bdsg/overlays/path_position_overlays.hpp line:30
+	{ // bdsg::PositionOverlay file:bdsg/overlays/path_position_overlays.hpp line:32
 		pybind11::class_<bdsg::PositionOverlay, std::shared_ptr<bdsg::PositionOverlay>, PyCallBack_bdsg_PositionOverlay, handlegraph::PathPositionHandleGraph, handlegraph::ExpandingOverlayGraph> cl(M("bdsg"), "PositionOverlay", "");
 		cl.def( pybind11::init( [](){ return new bdsg::PositionOverlay(); }, [](){ return new PyCallBack_bdsg_PositionOverlay(); } ) );
 		cl.def( pybind11::init( [](PyCallBack_bdsg_PositionOverlay const &o){ return new PyCallBack_bdsg_PositionOverlay(o); } ) );

--- a/bdsg/cmake_bindings/bdsg/overlays/path_position_overlays.cpp
+++ b/bdsg/cmake_bindings/bdsg/overlays/path_position_overlays.cpp
@@ -11,10 +11,12 @@
 #include <handlegraph/path_metadata.hpp>
 #include <handlegraph/path_position_handle_graph.hpp>
 #include <handlegraph/types.hpp>
-#include <iterator>
 #include <memory>
 #include <sstream> // __str__
 #include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -35,7 +37,7 @@
 	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
 #endif
 
-// bdsg::MutablePositionOverlay file:bdsg/overlays/path_position_overlays.hpp line:261
+// bdsg::MutablePositionOverlay file:bdsg/overlays/path_position_overlays.hpp line:268
 struct PyCallBack_bdsg_MutablePositionOverlay : public bdsg::MutablePositionOverlay {
 	using bdsg::MutablePositionOverlay::MutablePositionOverlay;
 
@@ -1299,11 +1301,8 @@ struct PyCallBack_bdsg_SubgraphOverlay : public bdsg::SubgraphOverlay {
 
 void bind_bdsg_overlays_path_position_overlays(std::function< pybind11::module &(std::string const &namespace_) > &M)
 {
-	{ // bdsg::MutablePositionOverlay file:bdsg/overlays/path_position_overlays.hpp line:261
+	{ // bdsg::MutablePositionOverlay file:bdsg/overlays/path_position_overlays.hpp line:268
 		pybind11::class_<bdsg::MutablePositionOverlay, std::shared_ptr<bdsg::MutablePositionOverlay>, PyCallBack_bdsg_MutablePositionOverlay, bdsg::PositionOverlay, handlegraph::MutablePathDeletableHandleGraph> cl(M("bdsg"), "MutablePositionOverlay", "");
-		cl.def( pybind11::init<class handlegraph::MutablePathDeletableHandleGraph *>(), pybind11::arg("graph") );
-
-		cl.def( pybind11::init( [](){ return new bdsg::MutablePositionOverlay(); }, [](){ return new PyCallBack_bdsg_MutablePositionOverlay(); } ) );
 		cl.def( pybind11::init( [](PyCallBack_bdsg_MutablePositionOverlay const &o){ return new PyCallBack_bdsg_MutablePositionOverlay(o); } ) );
 		cl.def( pybind11::init( [](bdsg::MutablePositionOverlay const &o){ return new bdsg::MutablePositionOverlay(o); } ) );
 		cl.def("create_handle", (struct handlegraph::handle_t (bdsg::MutablePositionOverlay::*)(const std::string &)) &bdsg::MutablePositionOverlay::create_handle, "Create a new node with the given sequence and return the handle.\n\nC++: bdsg::MutablePositionOverlay::create_handle(const std::string &) --> struct handlegraph::handle_t", pybind11::arg("sequence"));

--- a/bdsg/cmake_bindings/bdsg/overlays/path_subgraph_overlay.cpp
+++ b/bdsg/cmake_bindings/bdsg/overlays/path_subgraph_overlay.cpp
@@ -5,10 +5,12 @@
 #include <handlegraph/path_handle_graph.hpp>
 #include <handlegraph/path_metadata.hpp>
 #include <handlegraph/types.hpp>
-#include <iterator>
 #include <memory>
 #include <sstream> // __str__
 #include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/bdsg/cmake_bindings/bdsg/overlays/reference_path_overlay.cpp
+++ b/bdsg/cmake_bindings/bdsg/overlays/reference_path_overlay.cpp
@@ -6,10 +6,10 @@
 #include <handlegraph/path_metadata.hpp>
 #include <handlegraph/path_position_handle_graph.hpp>
 #include <handlegraph/types.hpp>
-#include <iterator>
 #include <memory>
 #include <sstream> // __str__
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -32,7 +32,7 @@
 	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
 #endif
 
-// bdsg::ReferencePathOverlay file:bdsg/overlays/reference_path_overlay.hpp line:41
+// bdsg::ReferencePathOverlay file:bdsg/overlays/reference_path_overlay.hpp line:32
 struct PyCallBack_bdsg_ReferencePathOverlay : public bdsg::ReferencePathOverlay {
 	using bdsg::ReferencePathOverlay::ReferencePathOverlay;
 
@@ -1048,7 +1048,7 @@ struct PyCallBack_bdsg_VectorizableOverlay : public bdsg::VectorizableOverlay {
 
 void bind_bdsg_overlays_reference_path_overlay(std::function< pybind11::module &(std::string const &namespace_) > &M)
 {
-	{ // bdsg::ReferencePathOverlay file:bdsg/overlays/reference_path_overlay.hpp line:41
+	{ // bdsg::ReferencePathOverlay file:bdsg/overlays/reference_path_overlay.hpp line:32
 		pybind11::class_<bdsg::ReferencePathOverlay, std::shared_ptr<bdsg::ReferencePathOverlay>, PyCallBack_bdsg_ReferencePathOverlay, handlegraph::PathPositionHandleGraph> cl(M("bdsg"), "ReferencePathOverlay", "");
 		cl.def( pybind11::init( [](){ return new bdsg::ReferencePathOverlay(); }, [](){ return new PyCallBack_bdsg_ReferencePathOverlay(); } ) );
 		cl.def( pybind11::init( [](PyCallBack_bdsg_ReferencePathOverlay const &o){ return new PyCallBack_bdsg_ReferencePathOverlay(o); } ) );

--- a/bdsg/cmake_bindings/bdsg/overlays/strand_split_overlay.cpp
+++ b/bdsg/cmake_bindings/bdsg/overlays/strand_split_overlay.cpp
@@ -2,10 +2,10 @@
 #include <functional>
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/types.hpp>
-#include <iterator>
 #include <memory>
 #include <sstream> // __str__
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include <functional>

--- a/bdsg/cmake_bindings/bdsg/overlays/vectorizable_overlays.cpp
+++ b/bdsg/cmake_bindings/bdsg/overlays/vectorizable_overlays.cpp
@@ -5,10 +5,10 @@
 #include <handlegraph/path_metadata.hpp>
 #include <handlegraph/path_position_handle_graph.hpp>
 #include <handlegraph/types.hpp>
-#include <iterator>
 #include <memory>
 #include <sstream> // __str__
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 

--- a/bdsg/cmake_bindings/bdsg/packed_graph.cpp
+++ b/bdsg/cmake_bindings/bdsg/packed_graph.cpp
@@ -1,3 +1,4 @@
+#include <__ostream/basic_ostream.h>
 #include <bdsg/internal/base_packed_graph.hpp>
 #include <bdsg/internal/graph_proxy_handle_graph_fragment.classfragment>
 #include <bdsg/internal/graph_proxy_mutable_path_deletable_handle_graph_fragment.classfragment>
@@ -10,12 +11,11 @@
 #include <handlegraph/types.hpp>
 #include <ios>
 #include <istream>
-#include <iterator>
 #include <memory>
-#include <ostream>
 #include <sstream> // __str__
 #include <streambuf>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>

--- a/bdsg/cmake_bindings/bdsg/snarl_distance_index.cpp
+++ b/bdsg/cmake_bindings/bdsg/snarl_distance_index.cpp
@@ -430,26 +430,6 @@ void bind_bdsg_snarl_distance_index(std::function< pybind11::module &(std::strin
 			.export_values();
 
 
-		pybind11::enum_<bdsg::SnarlDistanceIndex::record_t>(cl, "record_t", pybind11::arithmetic(), "A record_t is the type of structure that a record can be.\n The actual distance index is stored as a series of \"records\" for each snarl/node/chain. \n The record type defines what is stored in a record\n\nNODE, SNARL, and CHAIN indicate that they don't store distances.\nSIMPLE_SNARL is a snarl with all children connecting only to the boundary nodes in one direction (ie, a bubble).\nTRIVIAL_SNARL represents consecutive nodes in a chain. \nNODE represents a node that is a trivial chain. A node can only be the child of a snarl.\nOVERSIZED_SNARL only stores distances to the boundaries.\nROOT_SNARL represents a connected component of the root. It has no start or end node so \n   its children technically belong to the root.\nMULTICOMPONENT_CHAIN can represent a chain with snarls that are not start-end connected.\n    The chain is split up into components between these snarls, each node is tagged with\n    which component it belongs to.")
-			.value("ROOT", bdsg::SnarlDistanceIndex::ROOT)
-			.value("NODE", bdsg::SnarlDistanceIndex::NODE)
-			.value("DISTANCED_NODE", bdsg::SnarlDistanceIndex::DISTANCED_NODE)
-			.value("TRIVIAL_SNARL", bdsg::SnarlDistanceIndex::TRIVIAL_SNARL)
-			.value("DISTANCED_TRIVIAL_SNARL", bdsg::SnarlDistanceIndex::DISTANCED_TRIVIAL_SNARL)
-			.value("SIMPLE_SNARL", bdsg::SnarlDistanceIndex::SIMPLE_SNARL)
-			.value("DISTANCED_SIMPLE_SNARL", bdsg::SnarlDistanceIndex::DISTANCED_SIMPLE_SNARL)
-			.value("SNARL", bdsg::SnarlDistanceIndex::SNARL)
-			.value("DISTANCED_SNARL", bdsg::SnarlDistanceIndex::DISTANCED_SNARL)
-			.value("OVERSIZED_SNARL", bdsg::SnarlDistanceIndex::OVERSIZED_SNARL)
-			.value("ROOT_SNARL", bdsg::SnarlDistanceIndex::ROOT_SNARL)
-			.value("DISTANCED_ROOT_SNARL", bdsg::SnarlDistanceIndex::DISTANCED_ROOT_SNARL)
-			.value("CHAIN", bdsg::SnarlDistanceIndex::CHAIN)
-			.value("DISTANCED_CHAIN", bdsg::SnarlDistanceIndex::DISTANCED_CHAIN)
-			.value("MULTICOMPONENT_CHAIN", bdsg::SnarlDistanceIndex::MULTICOMPONENT_CHAIN)
-			.value("CHILDREN", bdsg::SnarlDistanceIndex::CHILDREN)
-			.export_values();
-
-
 		pybind11::enum_<bdsg::SnarlDistanceIndex::temp_record_t>(cl, "temp_record_t", pybind11::arithmetic(), "")
 			.value("TEMP_CHAIN", bdsg::SnarlDistanceIndex::TEMP_CHAIN)
 			.value("TEMP_SNARL", bdsg::SnarlDistanceIndex::TEMP_SNARL)
@@ -541,8 +521,6 @@ void bind_bdsg_snarl_distance_index(std::function< pybind11::module &(std::strin
 		cl.def("has_distances", (bool (bdsg::SnarlDistanceIndex::*)(const struct handlegraph::net_handle_t &) const) &bdsg::SnarlDistanceIndex::has_distances, "Does this net handle store distances?\n\nC++: bdsg::SnarlDistanceIndex::has_distances(const struct handlegraph::net_handle_t &) const --> bool", pybind11::arg("net"));
 		cl.def("has_distances", (bool (bdsg::SnarlDistanceIndex::*)() const) &bdsg::SnarlDistanceIndex::has_distances, "Does the distance index in general store distances?\n\nC++: bdsg::SnarlDistanceIndex::has_distances() const --> bool");
 		cl.def("get_parent_traversal", (struct handlegraph::net_handle_t (bdsg::SnarlDistanceIndex::*)(const struct handlegraph::net_handle_t &, const struct handlegraph::net_handle_t &) const) &bdsg::SnarlDistanceIndex::get_parent_traversal, "Get a net handle for traversals of a snarl or chain that contains\nthe given oriented bounding node traversals or sentinels. Given two\nsentinels for a snarl, produces a net handle to a start-to-end,\nend-to-end, end-to-start, or start-to-start traversal of that snarl.\nGiven handles to traversals of the bounding nodes of a chain, similarly\nproduces a net handle to a traversal of the chain.\n\nFor a chain, either or both handles can also be a snarl containing tips,\nfor a tip-to-start, tip-to-end, start-to-tip, end-to-tip, or tip-to-tip\ntraversal. Similarly, for a snarl, either or both handles can be a chain\nin the snarl that contains internal tips, or that has no edges on the\nappropriate end.\n\nMay only be called if a path actually exists between the given start\nand end.\n\nC++: bdsg::SnarlDistanceIndex::get_parent_traversal(const struct handlegraph::net_handle_t &, const struct handlegraph::net_handle_t &) const --> struct handlegraph::net_handle_t", pybind11::arg("traversal_start"), pybind11::arg("traversal_end"));
-		cl.def_static("has_distances", (const bool (*)(enum bdsg::SnarlDistanceIndex::record_t)) &bdsg::SnarlDistanceIndex::has_distances, "C++: bdsg::SnarlDistanceIndex::has_distances(enum bdsg::SnarlDistanceIndex::record_t) --> const bool", pybind11::arg("type"));
-		cl.def_static("get_record_handle_type", (const enum bdsg::SnarlDistanceIndex::net_handle_record_t (*)(enum bdsg::SnarlDistanceIndex::record_t)) &bdsg::SnarlDistanceIndex::get_record_handle_type, "Given the type of the record, return the handle type. Some record types can represent multiple things,\nfor example a simple snarl record is used to represent a snarl, and the nodes/trivial chains in it.\nThis will return whatever is higher on the snarl tree. A simple snarl will be considered a snarl,\na root snarl will be considered a root, etc\n\nC++: bdsg::SnarlDistanceIndex::get_record_handle_type(enum bdsg::SnarlDistanceIndex::record_t) --> const enum bdsg::SnarlDistanceIndex::net_handle_record_t", pybind11::arg("type"));
 		cl.def_static("get_record_offset", (const unsigned long (*)(const struct handlegraph::net_handle_t &)) &bdsg::SnarlDistanceIndex::get_record_offset, "The offset into records that this handle points to\n\nC++: bdsg::SnarlDistanceIndex::get_record_offset(const struct handlegraph::net_handle_t &) --> const unsigned long", pybind11::arg("net_handle"));
 		cl.def_static("get_node_record_offset", (const unsigned long (*)(const struct handlegraph::net_handle_t &)) &bdsg::SnarlDistanceIndex::get_node_record_offset, "The offset of a node in a trivial snarl (0 if it isn't a node in a trivial snarl)\n\nC++: bdsg::SnarlDistanceIndex::get_node_record_offset(const struct handlegraph::net_handle_t &) --> const unsigned long", pybind11::arg("net_handle"));
 		cl.def_static("get_connectivity", (const enum bdsg::SnarlDistanceIndex::connectivity_t (*)(const struct handlegraph::net_handle_t &)) &bdsg::SnarlDistanceIndex::get_connectivity, "C++: bdsg::SnarlDistanceIndex::get_connectivity(const struct handlegraph::net_handle_t &) --> const enum bdsg::SnarlDistanceIndex::connectivity_t", pybind11::arg("net_handle"));

--- a/bdsg/cmake_bindings/bdsg/snarl_distance_index.cpp
+++ b/bdsg/cmake_bindings/bdsg/snarl_distance_index.cpp
@@ -1,3 +1,4 @@
+#include <__ostream/basic_ostream.h>
 #include <bdsg/snarl_distance_index.hpp>
 #include <functional>
 #include <handlegraph/handle_graph.hpp>
@@ -6,12 +7,11 @@
 #include <handlegraph/types.hpp>
 #include <ios>
 #include <istream>
-#include <iterator>
 #include <memory>
-#include <ostream>
 #include <sstream> // __str__
 #include <streambuf>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <utility>
 
@@ -463,6 +463,7 @@ void bind_bdsg_snarl_distance_index(std::function< pybind11::module &(std::strin
 		cl.def("serialize", (void (bdsg::SnarlDistanceIndex::*)(const class std::function<void (const void *, unsigned long)> &) const) &bdsg::SnarlDistanceIndex::serialize, "C++: bdsg::SnarlDistanceIndex::serialize(const class std::function<void (const void *, unsigned long)> &) const --> void", pybind11::arg("iteratee"));
 		cl.def("serialize", (void (bdsg::SnarlDistanceIndex::*)(int)) &bdsg::SnarlDistanceIndex::serialize, "C++: bdsg::SnarlDistanceIndex::serialize(int) --> void", pybind11::arg("fd"));
 		cl.def("deserialize", (void (bdsg::SnarlDistanceIndex::*)(int)) &bdsg::SnarlDistanceIndex::deserialize, "C++: bdsg::SnarlDistanceIndex::deserialize(int) --> void", pybind11::arg("fd"));
+		cl.def("check_version_on_load", (void (bdsg::SnarlDistanceIndex::*)() const) &bdsg::SnarlDistanceIndex::check_version_on_load, "Call when loading a distance index; will error if wrong version\n\nC++: bdsg::SnarlDistanceIndex::check_version_on_load() const --> void");
 		cl.def("get_magic_number", (unsigned int (bdsg::SnarlDistanceIndex::*)() const) &bdsg::SnarlDistanceIndex::get_magic_number, "C++: bdsg::SnarlDistanceIndex::get_magic_number() const --> unsigned int");
 		cl.def("get_prefix", (std::string (bdsg::SnarlDistanceIndex::*)() const) &bdsg::SnarlDistanceIndex::get_prefix, "C++: bdsg::SnarlDistanceIndex::get_prefix() const --> std::string");
 		cl.def("preload", [](bdsg::SnarlDistanceIndex const &o) -> void { return o.preload(); }, "");
@@ -512,9 +513,12 @@ void bind_bdsg_snarl_distance_index(std::function< pybind11::module &(std::strin
 		cl.def("is_root", (bool (bdsg::SnarlDistanceIndex::*)(const struct handlegraph::net_handle_t &) const) &bdsg::SnarlDistanceIndex::is_root, "Return true if the given handle refers to (a traversal of) the root\nsnarl, and false otherwise.\n\nC++: bdsg::SnarlDistanceIndex::is_root(const struct handlegraph::net_handle_t &) const --> bool", pybind11::arg("net"));
 		cl.def("is_root_snarl", (bool (bdsg::SnarlDistanceIndex::*)(const struct handlegraph::net_handle_t &) const) &bdsg::SnarlDistanceIndex::is_root_snarl, "Return true if the given handle refers to (a traversal of) a snarl of the root,\nwhich is considered to be the root but actually refers to a subset of the children \nof the root that are connected\n\nC++: bdsg::SnarlDistanceIndex::is_root_snarl(const struct handlegraph::net_handle_t &) const --> bool", pybind11::arg("net"));
 		cl.def("is_snarl", (bool (bdsg::SnarlDistanceIndex::*)(const struct handlegraph::net_handle_t &) const) &bdsg::SnarlDistanceIndex::is_snarl, "Returns true if the given net handle refers to (a traversal of) a snarl.\n\nC++: bdsg::SnarlDistanceIndex::is_snarl(const struct handlegraph::net_handle_t &) const --> bool", pybind11::arg("net"));
+		cl.def("is_oversized_snarl", (bool (bdsg::SnarlDistanceIndex::*)(const struct handlegraph::net_handle_t &) const) &bdsg::SnarlDistanceIndex::is_oversized_snarl, "Returns true if the given net handle refers to (a traversal of) an oversized snarl.\n\nC++: bdsg::SnarlDistanceIndex::is_oversized_snarl(const struct handlegraph::net_handle_t &) const --> bool", pybind11::arg("net"));
 		cl.def("is_dag", (bool (bdsg::SnarlDistanceIndex::*)(const struct handlegraph::net_handle_t &) const) &bdsg::SnarlDistanceIndex::is_dag, "Return true if the given snarl is a DAG and false otherwise\nReturns true if the given net_handle_t is not a snarl\n\nC++: bdsg::SnarlDistanceIndex::is_dag(const struct handlegraph::net_handle_t &) const --> bool", pybind11::arg("snarl"));
 		cl.def("is_simple_snarl", (bool (bdsg::SnarlDistanceIndex::*)(const struct handlegraph::net_handle_t &) const) &bdsg::SnarlDistanceIndex::is_simple_snarl, "Returns true if the given net handle refers to (a traversal of) a simple snarl\nA simple snarl is a bubble where each child node can only reach the boundary nodes,\nand each side of a node reaches a different boundary node\nThere may also be an edge connecting the two boundary nodes but no additional \nedges are allowed\n\nC++: bdsg::SnarlDistanceIndex::is_simple_snarl(const struct handlegraph::net_handle_t &) const --> bool", pybind11::arg("net"));
-		cl.def("is_regular_snarl", (bool (bdsg::SnarlDistanceIndex::*)(const struct handlegraph::net_handle_t &) const) &bdsg::SnarlDistanceIndex::is_regular_snarl, "Returns true if the given net handle refers to (a traversal of) a regular snarl\nA regular snarl is the same as a simple snarl, except that the children may be\nnested chains, rather than being restricted to nodes \n\nC++: bdsg::SnarlDistanceIndex::is_regular_snarl(const struct handlegraph::net_handle_t &) const --> bool", pybind11::arg("net"));
+		cl.def("is_regular_snarl", [](bdsg::SnarlDistanceIndex const &o, const struct handlegraph::net_handle_t & a0) -> bool { return o.is_regular_snarl(a0); }, "", pybind11::arg("net"));
+		cl.def("is_regular_snarl", [](bdsg::SnarlDistanceIndex const &o, const struct handlegraph::net_handle_t & a0, bool const & a1) -> bool { return o.is_regular_snarl(a0, a1); }, "", pybind11::arg("net"), pybind11::arg("allow_internal_loops"));
+		cl.def("is_regular_snarl", (bool (bdsg::SnarlDistanceIndex::*)(const struct handlegraph::net_handle_t &, bool, const class handlegraph::HandleGraph *) const) &bdsg::SnarlDistanceIndex::is_regular_snarl, "Returns true if the given net handle refers to (a traversal of) a regular snarl\nA regular snarl is the same as a simple snarl, except that the children may be\nnested chains, rather than being restricted to nodes \n\nC++: bdsg::SnarlDistanceIndex::is_regular_snarl(const struct handlegraph::net_handle_t &, bool, const class handlegraph::HandleGraph *) const --> bool", pybind11::arg("net"), pybind11::arg("allow_internal_loops"), pybind11::arg("graph"));
 		cl.def("is_chain", (bool (bdsg::SnarlDistanceIndex::*)(const struct handlegraph::net_handle_t &) const) &bdsg::SnarlDistanceIndex::is_chain, "Returns true if the given net handle refers to (a traversal of) a chain.\n\nC++: bdsg::SnarlDistanceIndex::is_chain(const struct handlegraph::net_handle_t &) const --> bool", pybind11::arg("net"));
 		cl.def("is_multicomponent_chain", (bool (bdsg::SnarlDistanceIndex::*)(const struct handlegraph::net_handle_t &) const) &bdsg::SnarlDistanceIndex::is_multicomponent_chain, "Returns true if the given net handle refers to (a traversal of) a chain that is not start-end connected\n\nC++: bdsg::SnarlDistanceIndex::is_multicomponent_chain(const struct handlegraph::net_handle_t &) const --> bool", pybind11::arg("net"));
 		cl.def("is_looping_chain", (bool (bdsg::SnarlDistanceIndex::*)(const struct handlegraph::net_handle_t &) const) &bdsg::SnarlDistanceIndex::is_looping_chain, "Returns true if the given net handle refers to (a traversal of) a chain that loops (a chain where the first and last node are the same).\n\nC++: bdsg::SnarlDistanceIndex::is_looping_chain(const struct handlegraph::net_handle_t &) const --> bool", pybind11::arg("net"));
@@ -534,6 +538,8 @@ void bind_bdsg_snarl_distance_index(std::function< pybind11::module &(std::strin
 		cl.def("get_rank_in_parent", (unsigned long (bdsg::SnarlDistanceIndex::*)(const struct handlegraph::net_handle_t &) const) &bdsg::SnarlDistanceIndex::get_rank_in_parent, "For a child of a snarl, the rank is used to calculate the distance\n\nC++: bdsg::SnarlDistanceIndex::get_rank_in_parent(const struct handlegraph::net_handle_t &) const --> unsigned long", pybind11::arg("net"));
 		cl.def("connected_component_count", (unsigned long (bdsg::SnarlDistanceIndex::*)() const) &bdsg::SnarlDistanceIndex::connected_component_count, "How many connected components are in this graph?\nThis returns the number of topological connected components, not necessarily the \nnumber of nodes in the top-level snarl \n\nC++: bdsg::SnarlDistanceIndex::connected_component_count() const --> unsigned long");
 		cl.def("get_snarl_child_from_rank", (struct handlegraph::net_handle_t (bdsg::SnarlDistanceIndex::*)(const struct handlegraph::net_handle_t &, const unsigned long &) const) &bdsg::SnarlDistanceIndex::get_snarl_child_from_rank, "Get the child of a snarl from its rank. This shouldn't be exposed to the public interface but I need it\nPlease don't use it\nFor 0 or 1, returns the sentinel facing in. Otherwise return the child as a chain going START_END\n\nC++: bdsg::SnarlDistanceIndex::get_snarl_child_from_rank(const struct handlegraph::net_handle_t &, const unsigned long &) const --> struct handlegraph::net_handle_t", pybind11::arg("snarl"), pybind11::arg("rank"));
+		cl.def("has_distances", (bool (bdsg::SnarlDistanceIndex::*)(const struct handlegraph::net_handle_t &) const) &bdsg::SnarlDistanceIndex::has_distances, "Does this net handle store distances?\n\nC++: bdsg::SnarlDistanceIndex::has_distances(const struct handlegraph::net_handle_t &) const --> bool", pybind11::arg("net"));
+		cl.def("has_distances", (bool (bdsg::SnarlDistanceIndex::*)() const) &bdsg::SnarlDistanceIndex::has_distances, "Does the distance index in general store distances?\n\nC++: bdsg::SnarlDistanceIndex::has_distances() const --> bool");
 		cl.def("get_parent_traversal", (struct handlegraph::net_handle_t (bdsg::SnarlDistanceIndex::*)(const struct handlegraph::net_handle_t &, const struct handlegraph::net_handle_t &) const) &bdsg::SnarlDistanceIndex::get_parent_traversal, "Get a net handle for traversals of a snarl or chain that contains\nthe given oriented bounding node traversals or sentinels. Given two\nsentinels for a snarl, produces a net handle to a start-to-end,\nend-to-end, end-to-start, or start-to-start traversal of that snarl.\nGiven handles to traversals of the bounding nodes of a chain, similarly\nproduces a net handle to a traversal of the chain.\n\nFor a chain, either or both handles can also be a snarl containing tips,\nfor a tip-to-start, tip-to-end, start-to-tip, end-to-tip, or tip-to-tip\ntraversal. Similarly, for a snarl, either or both handles can be a chain\nin the snarl that contains internal tips, or that has no edges on the\nappropriate end.\n\nMay only be called if a path actually exists between the given start\nand end.\n\nC++: bdsg::SnarlDistanceIndex::get_parent_traversal(const struct handlegraph::net_handle_t &, const struct handlegraph::net_handle_t &) const --> struct handlegraph::net_handle_t", pybind11::arg("traversal_start"), pybind11::arg("traversal_end"));
 		cl.def_static("has_distances", (const bool (*)(enum bdsg::SnarlDistanceIndex::record_t)) &bdsg::SnarlDistanceIndex::has_distances, "C++: bdsg::SnarlDistanceIndex::has_distances(enum bdsg::SnarlDistanceIndex::record_t) --> const bool", pybind11::arg("type"));
 		cl.def_static("get_record_handle_type", (const enum bdsg::SnarlDistanceIndex::net_handle_record_t (*)(enum bdsg::SnarlDistanceIndex::record_t)) &bdsg::SnarlDistanceIndex::get_record_handle_type, "Given the type of the record, return the handle type. Some record types can represent multiple things,\nfor example a simple snarl record is used to represent a snarl, and the nodes/trivial chains in it.\nThis will return whatever is higher on the snarl tree. A simple snarl will be considered a snarl,\na root snarl will be considered a root, etc\n\nC++: bdsg::SnarlDistanceIndex::get_record_handle_type(enum bdsg::SnarlDistanceIndex::record_t) --> const enum bdsg::SnarlDistanceIndex::net_handle_record_t", pybind11::arg("type"));
@@ -571,7 +577,7 @@ void bind_bdsg_snarl_distance_index(std::function< pybind11::module &(std::strin
 		cl.def_static("bit_width", (unsigned long (*)(unsigned long)) &bdsg::SnarlDistanceIndex::bit_width, "C++: bdsg::SnarlDistanceIndex::bit_width(unsigned long) --> unsigned long", pybind11::arg("value"));
 		cl.def("time_accesses", (void (bdsg::SnarlDistanceIndex::*)()) &bdsg::SnarlDistanceIndex::time_accesses, "C++: bdsg::SnarlDistanceIndex::time_accesses() --> void");
 
-		{ // bdsg::SnarlDistanceIndex::TemporaryDistanceIndex file:bdsg/snarl_distance_index.hpp line:1524
+		{ // bdsg::SnarlDistanceIndex::TemporaryDistanceIndex file:bdsg/snarl_distance_index.hpp line:1555
 			auto & enclosing_class = cl;
 			pybind11::class_<bdsg::SnarlDistanceIndex::TemporaryDistanceIndex, std::shared_ptr<bdsg::SnarlDistanceIndex::TemporaryDistanceIndex>> cl(enclosing_class, "TemporaryDistanceIndex", "");
 			cl.def( pybind11::init( [](){ return new bdsg::SnarlDistanceIndex::TemporaryDistanceIndex(); } ) );
@@ -582,17 +588,19 @@ void bind_bdsg_snarl_distance_index(std::function< pybind11::module &(std::strin
 			cl.def_readwrite("max_tree_depth", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::max_tree_depth);
 			cl.def_readwrite("max_index_size", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::max_index_size);
 			cl.def_readwrite("max_distance", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::max_distance);
+			cl.def_readwrite("max_bits", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::max_bits);
 			cl.def_readwrite("components", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::components);
 			cl.def_readwrite("root_snarl_components", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::root_snarl_components);
 			cl.def_readwrite("temp_chain_records", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::temp_chain_records);
 			cl.def_readwrite("temp_snarl_records", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::temp_snarl_records);
 			cl.def_readwrite("temp_node_records", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::temp_node_records);
 			cl.def_readwrite("use_oversized_snarls", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::use_oversized_snarls);
+			cl.def_readwrite("most_oversized_snarl_size", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::most_oversized_snarl_size);
 			cl.def("structure_start_end_as_string", (std::string (bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::*)(struct std::pair<enum bdsg::SnarlDistanceIndex::temp_record_t, unsigned long>) const) &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::structure_start_end_as_string, "C++: bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::structure_start_end_as_string(struct std::pair<enum bdsg::SnarlDistanceIndex::temp_record_t, unsigned long>) const --> std::string", pybind11::arg("index"));
 			cl.def("get_max_record_length", (unsigned long (bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::*)() const) &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::get_max_record_length, "C++: bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::get_max_record_length() const --> unsigned long");
 			cl.def("assign", (class bdsg::SnarlDistanceIndex::TemporaryDistanceIndex & (bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::*)(const class bdsg::SnarlDistanceIndex::TemporaryDistanceIndex &)) &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::operator=, "C++: bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::operator=(const class bdsg::SnarlDistanceIndex::TemporaryDistanceIndex &) --> class bdsg::SnarlDistanceIndex::TemporaryDistanceIndex &", pybind11::return_value_policy::automatic, pybind11::arg(""));
 
-			{ // bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryRecord file:bdsg/snarl_distance_index.hpp line:1544
+			{ // bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryRecord file:bdsg/snarl_distance_index.hpp line:1577
 				auto & enclosing_class = cl;
 				pybind11::class_<bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryRecord, std::shared_ptr<bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryRecord>> cl(enclosing_class, "TemporaryRecord", "");
 				cl.def( pybind11::init( [](bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryRecord const &o){ return new bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryRecord(o); } ) );
@@ -600,7 +608,7 @@ void bind_bdsg_snarl_distance_index(std::function< pybind11::module &(std::strin
 				cl.def("assign", (struct bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryRecord & (bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryRecord::*)(const struct bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryRecord &)) &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryRecord::operator=, "C++: bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryRecord::operator=(const struct bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryRecord &) --> struct bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryRecord &", pybind11::return_value_policy::automatic, pybind11::arg(""));
 			}
 
-			{ // bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryChainRecord file:bdsg/snarl_distance_index.hpp line:1546
+			{ // bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryChainRecord file:bdsg/snarl_distance_index.hpp line:1579
 				auto & enclosing_class = cl;
 				pybind11::class_<bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryChainRecord, std::shared_ptr<bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryChainRecord>, bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryRecord> cl(enclosing_class, "TemporaryChainRecord", "");
 				cl.def( pybind11::init( [](){ return new bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryChainRecord(); } ) );
@@ -634,7 +642,7 @@ void bind_bdsg_snarl_distance_index(std::function< pybind11::module &(std::strin
 				cl.def("assign", (struct bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryChainRecord & (bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryChainRecord::*)(const struct bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryChainRecord &)) &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryChainRecord::operator=, "C++: bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryChainRecord::operator=(const struct bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryChainRecord &) --> struct bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryChainRecord &", pybind11::return_value_policy::automatic, pybind11::arg(""));
 			}
 
-			{ // bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord file:bdsg/snarl_distance_index.hpp line:1588
+			{ // bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord file:bdsg/snarl_distance_index.hpp line:1621
 				auto & enclosing_class = cl;
 				pybind11::class_<bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord, std::shared_ptr<bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord>, bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryRecord> cl(enclosing_class, "TemporarySnarlRecord", "");
 				cl.def( pybind11::init( [](){ return new bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord(); } ) );
@@ -652,6 +660,7 @@ void bind_bdsg_snarl_distance_index(std::function< pybind11::module &(std::strin
 				cl.def_readwrite("distance_start_start", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord::distance_start_start);
 				cl.def_readwrite("distance_end_end", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord::distance_end_end);
 				cl.def_readwrite("rank_in_parent", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord::rank_in_parent);
+				cl.def_readwrite("max_bits", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord::max_bits);
 				cl.def_readwrite("reversed_in_parent", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord::reversed_in_parent);
 				cl.def_readwrite("start_node_rev", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord::start_node_rev);
 				cl.def_readwrite("end_node_rev", &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord::end_node_rev);
@@ -667,7 +676,7 @@ void bind_bdsg_snarl_distance_index(std::function< pybind11::module &(std::strin
 				cl.def("assign", (struct bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord & (bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord::*)(const struct bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord &)) &bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord::operator=, "C++: bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord::operator=(const struct bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord &) --> struct bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporarySnarlRecord &", pybind11::return_value_policy::automatic, pybind11::arg(""));
 			}
 
-			{ // bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryNodeRecord file:bdsg/snarl_distance_index.hpp line:1621
+			{ // bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryNodeRecord file:bdsg/snarl_distance_index.hpp line:1661
 				auto & enclosing_class = cl;
 				pybind11::class_<bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryNodeRecord, std::shared_ptr<bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryNodeRecord>, bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryRecord> cl(enclosing_class, "TemporaryNodeRecord", "");
 				cl.def( pybind11::init( [](){ return new bdsg::SnarlDistanceIndex::TemporaryDistanceIndex::TemporaryNodeRecord(); } ) );

--- a/bdsg/cmake_bindings/handlegraph/expanding_overlay_graph.cpp
+++ b/bdsg/cmake_bindings/handlegraph/expanding_overlay_graph.cpp
@@ -2,10 +2,10 @@
 #include <handlegraph/expanding_overlay_graph.hpp>
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/types.hpp>
-#include <iterator>
 #include <memory>
 #include <sstream> // __str__
 #include <string>
+#include <string_view>
 
 #include <functional>
 #include <pybind11/pybind11.h>

--- a/bdsg/cmake_bindings/handlegraph/handle_graph.cpp
+++ b/bdsg/cmake_bindings/handlegraph/handle_graph.cpp
@@ -1,10 +1,10 @@
 #include <functional>
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/types.hpp>
-#include <iterator>
 #include <memory>
 #include <sstream> // __str__
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include <functional>

--- a/bdsg/cmake_bindings/handlegraph/mutable_path_metadata.cpp
+++ b/bdsg/cmake_bindings/handlegraph/mutable_path_metadata.cpp
@@ -6,10 +6,10 @@
 #include <handlegraph/path_handle_graph.hpp>
 #include <handlegraph/path_metadata.hpp>
 #include <handlegraph/types.hpp>
-#include <iterator>
 #include <memory>
 #include <sstream> // __str__
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 

--- a/bdsg/cmake_bindings/handlegraph/mutable_path_mutable_handle_graph.cpp
+++ b/bdsg/cmake_bindings/handlegraph/mutable_path_mutable_handle_graph.cpp
@@ -1,3 +1,4 @@
+#include <__ostream/basic_ostream.h>
 #include <functional>
 #include <handlegraph/deletable_handle_graph.hpp>
 #include <handlegraph/handle_graph.hpp>
@@ -13,12 +14,11 @@
 #include <handlegraph/types.hpp>
 #include <ios>
 #include <istream>
-#include <iterator>
 #include <memory>
-#include <ostream>
 #include <sstream> // __str__
 #include <streambuf>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 

--- a/bdsg/cmake_bindings/handlegraph/path_handle_graph.cpp
+++ b/bdsg/cmake_bindings/handlegraph/path_handle_graph.cpp
@@ -3,10 +3,10 @@
 #include <handlegraph/path_handle_graph.hpp>
 #include <handlegraph/snarl_decomposition.hpp>
 #include <handlegraph/types.hpp>
-#include <iterator>
 #include <memory>
 #include <sstream> // __str__
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include <functional>

--- a/bdsg/cmake_bindings/handlegraph/path_metadata.cpp
+++ b/bdsg/cmake_bindings/handlegraph/path_metadata.cpp
@@ -3,10 +3,10 @@
 #include <handlegraph/path_handle_graph.hpp>
 #include <handlegraph/path_metadata.hpp>
 #include <handlegraph/types.hpp>
-#include <iterator>
 #include <memory>
 #include <sstream> // __str__
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 

--- a/bdsg/cmake_bindings/handlegraph/path_position_handle_graph.cpp
+++ b/bdsg/cmake_bindings/handlegraph/path_position_handle_graph.cpp
@@ -4,10 +4,10 @@
 #include <handlegraph/path_metadata.hpp>
 #include <handlegraph/path_position_handle_graph.hpp>
 #include <handlegraph/types.hpp>
-#include <iterator>
 #include <memory>
 #include <sstream> // __str__
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 

--- a/bdsg/cmake_bindings/handlegraph/trivially_serializable.cpp
+++ b/bdsg/cmake_bindings/handlegraph/trivially_serializable.cpp
@@ -1,13 +1,13 @@
+#include <__ostream/basic_ostream.h>
 #include <functional>
 #include <handlegraph/trivially_serializable.hpp>
 #include <ios>
 #include <istream>
-#include <iterator>
 #include <memory>
-#include <ostream>
 #include <sstream> // __str__
 #include <streambuf>
 #include <string>
+#include <string_view>
 
 #include <functional>
 #include <pybind11/pybind11.h>

--- a/bdsg/cmake_bindings/handlegraph/types.cpp
+++ b/bdsg/cmake_bindings/handlegraph/types.cpp
@@ -42,13 +42,15 @@ void bind_handlegraph_types(std::function< pybind11::module &(std::string const 
 
 	{ // handlegraph::step_handle_t file:handlegraph/types.hpp line:55
 		pybind11::class_<handlegraph::step_handle_t, std::shared_ptr<handlegraph::step_handle_t>> cl(M("handlegraph"), "step_handle_t", "A step handle is an opaque reference to a single step of an oriented node on a path in a graph");
-		cl.def( pybind11::init( [](){ return new handlegraph::step_handle_t(); } ) );
 		cl.def( pybind11::init( [](handlegraph::step_handle_t const &o){ return new handlegraph::step_handle_t(o); } ) );
+		cl.def( pybind11::init( [](){ return new handlegraph::step_handle_t(); } ) );
 		cl.def("assign", (struct handlegraph::step_handle_t & (handlegraph::step_handle_t::*)(const struct handlegraph::step_handle_t &)) &handlegraph::step_handle_t::operator=, "C++: handlegraph::step_handle_t::operator=(const struct handlegraph::step_handle_t &) --> struct handlegraph::step_handle_t &", pybind11::return_value_policy::automatic, pybind11::arg(""));
 	}
 	{ // handlegraph::net_handle_t file:handlegraph/types.hpp line:73
 		pybind11::class_<handlegraph::net_handle_t, std::shared_ptr<handlegraph::net_handle_t>> cl(M("handlegraph"), "net_handle_t", "A net handle is an opaque reference to a category of traversals of a single\n node, a chain, or the interior of a snarl, in the snarl decomposition of a\n graph.\n\n Snarls and chains are bounded by two particular points, but the traversal\n may not visit both or any of them (as is the case for traversals between\n internal tips).\n\n The handle refers to the snarl or chain itself and also a particular\n category of traversals of it. Each of the start and end of the traversal can\n be the start of the snarl/chain, the end of the snarl/chain, or some\n internal tip, for 6 distinct combinations.\n\n For single nodes, we only have forward and reverse.");
 		cl.def( pybind11::init( [](){ return new handlegraph::net_handle_t(); } ) );
 		cl.def( pybind11::init( [](handlegraph::net_handle_t const &o){ return new handlegraph::net_handle_t(o); } ) );
+		cl.def("__eq__", (bool (handlegraph::net_handle_t::*)(const struct handlegraph::net_handle_t &) const) &handlegraph::net_handle_t::operator==, "Define equality on net handles\n\nC++: handlegraph::net_handle_t::operator==(const struct handlegraph::net_handle_t &) const --> bool", pybind11::arg("other"));
+		cl.def("__ne__", (bool (handlegraph::net_handle_t::*)(const struct handlegraph::net_handle_t &) const) &handlegraph::net_handle_t::operator!=, "Define inequality on net handles\n\nC++: handlegraph::net_handle_t::operator!=(const struct handlegraph::net_handle_t &) const --> bool", pybind11::arg("other"));
 	}
 }

--- a/bdsg/cmake_bindings/std/bdsg/internal/binder_hook_bind.cpp
+++ b/bdsg/cmake_bindings/std/bdsg/internal/binder_hook_bind.cpp
@@ -1,5 +1,4 @@
 #include <handlegraph/types.hpp>
-#include <iterator>
 #include <memory>
 #include <sstream> // __str__
 #include <stl_binders.hpp>

--- a/bdsg/include/bdsg/overlays/packed_path_position_overlay.hpp
+++ b/bdsg/include/bdsg/overlays/packed_path_position_overlay.hpp
@@ -44,12 +44,21 @@ protected:
 public:
     
     /// Make a new PackedPositionOverlay, on the given graph, indexing GENERIC
-    /// and REFERENCE sense paths.
+    /// and REFERENCE sense paths (or all paths if all_paths is set), plus any
+    /// paths that appear in extra_path_names.
     ///
     /// Glom short paths together to make internal indexes each over at least
-    /// the given number of steps. Indexes any hidden paths that appear in
+    /// the given number of steps.
+    PackedPositionOverlay(const PathHandleGraph* graph, bool all_paths, const std::unordered_set<std::string>& extra_path_names = {}, size_t steps_per_index = 20000000);
+    
+    /// Make a new PackedPositionOverlay, on the given graph, indexing GENERIC
+    /// and REFERENCE sense paths, plus any paths that appear in
     /// extra_path_names.
+    ///
+    /// Glom short paths together to make internal indexes each over at least
+    /// the given number of steps.
     PackedPositionOverlay(const PathHandleGraph* graph, const std::unordered_set<std::string>& extra_path_names = {}, size_t steps_per_index = 20000000);
+    
     PackedPositionOverlay(const PackedPositionOverlay& other) = default;
     PackedPositionOverlay(PackedPositionOverlay&& other) = default;
     ~PackedPositionOverlay() = default;

--- a/bdsg/include/bdsg/overlays/packed_path_position_overlay.hpp
+++ b/bdsg/include/bdsg/overlays/packed_path_position_overlay.hpp
@@ -27,19 +27,28 @@ using namespace handlegraph;
  * An overlay that adds the PathPositionHandleGraph interface to a static PathHandleGraph
  * by augmenting it with compressed index data structures.
  *
- * TODO: Make the overlay transparent so that paths hidden in the base graph
- * remain accessible through the path metadata queries. 
+ * In this implementation (though not necessarily in descendant classes), the
+ * overlay is semi-transparent: paths which are not indexed still exist and can
+ * be worked with, but position requests involving them will throw
+ * std::logic_error.
  */
 class PackedPositionOverlay : public PathPositionHandleGraph, public ExpandingOverlayGraph {
 
 protected:
     PackedPositionOverlay() = default;
 
+    /// Make a new PackedPositionOverlay, filling in the graph and
+    /// steps_per_index members but not actually building the indexes.
+    PackedPositionOverlay(const PathHandleGraph* graph, size_t steps_per_index);
+
 public:
     
-    /// Make a new PackedPositionOverlay, on the given graph. Glom short paths
-    /// together to make internal indexes each over at least the given number
-    /// of steps. Indexes any hidden paths that appear in extra_path_names.
+    /// Make a new PackedPositionOverlay, on the given graph, indexing GENERIC
+    /// and REFERENCE sense paths.
+    ///
+    /// Glom short paths together to make internal indexes each over at least
+    /// the given number of steps. Indexes any hidden paths that appear in
+    /// extra_path_names.
     PackedPositionOverlay(const PathHandleGraph* graph, const std::unordered_set<std::string>& extra_path_names = {}, size_t steps_per_index = 20000000);
     PackedPositionOverlay(const PackedPositionOverlay& other) = default;
     PackedPositionOverlay(PackedPositionOverlay&& other) = default;
@@ -249,8 +258,10 @@ protected:
     };
     
     /// Construct the index over path positions.
-    /// Always includes paths with names in the given set, even if they are hidden.
-    void index_path_positions(const std::unordered_set<std::string>& extra_path_names = {});
+    ///
+    /// If all_paths is set, indexes all paths. Otherwise, indexes REFERENCE
+    /// and GENERIC sense paths, plus those in the given set.
+    void index_path_positions(bool all_paths, const std::unordered_set<std::string>& extra_path_names = {});
     
     /// Get the length in steps of the given path. Also do any scanning necessary for the path to generate per-path user data.
     virtual size_t scan_path(const path_handle_t& path_handle, void*& user_data);

--- a/bdsg/include/bdsg/overlays/packed_reference_path_overlay.hpp
+++ b/bdsg/include/bdsg/overlays/packed_reference_path_overlay.hpp
@@ -61,9 +61,6 @@ public:
 
 protected:
 
-    /// Whether to index all paths (true) or only REFERENCE and GENERIC paths (false).
-    bool all_paths = true;
-
     // PathHandleGraph interface
 
     /// Override to filter paths to those that are indexed. 

--- a/bdsg/include/bdsg/overlays/packed_reference_path_overlay.hpp
+++ b/bdsg/include/bdsg/overlays/packed_reference_path_overlay.hpp
@@ -19,16 +19,9 @@ using namespace handlegraph;
  * An overlay that adds fast access to paths in addition to allowing path
  * position queries on them.
  *
- * TODO: Won't work properly with paths hidden from for_each_path_handle on the
- * backing graph and don't appear in extra_path_names, since they won't be
- * indexed.
- *
- * We also won't pass any kind of queries through to the backing graph for
- * queries we expect to be able to fulfil from the index. Unkike in
- * PackedPositionOverlay, we now expect the index to have some path data in it,
- * not just offset tables that we wouldn't expect to use for hidden (i,e,
- * haplotype) paths. We should make the overlay transparent so hidden paths
- * work properly, or remove hidden paths.
+ * Unkike in PackedPositionOverlay, we now expect the index to have some path
+ * data in it, not just offset tables, so we only present paths that have been
+ * indexed (by default, REFERENCE and GENERIC sense paths).
  */
 class PackedReferencePathOverlay : public PackedPositionOverlay {
 
@@ -37,21 +30,34 @@ protected:
 
 public:
     
-    /// Make a PackedReferencePathOverlay. Do the indexing and compute the
-    /// additional indexes that the base class doesn't have.
+    /// Make a PackedReferencePathOverlay with path filtering.
+    ///
+    /// If all_paths is true, indexes all paths visible via
+    /// for_each_path_handle().
+    ///
+    /// If false, indexes only REFERENCE and GENERIC sense paths, plus those in
+    /// extra_path_names.
+    ///
+    /// Do the indexing and compute the additional indexes that the base class
+    /// doesn't have.
+    PackedReferencePathOverlay(const PathHandleGraph* graph, bool all_paths, const std::unordered_set<std::string>& extra_path_names = {}, size_t steps_per_index = 20000000);
+
+    /// Make a PackedReferencePathOverlay indexing REFERENCE and GENERIC paths,
+    /// plus those in extra_path_names. 
     PackedReferencePathOverlay(const PathHandleGraph* graph, const std::unordered_set<std::string>& extra_path_names = {}, size_t steps_per_index = 20000000);
 
-    /// Make a PackedReferencePathOverlay with path filtering.
-    /// If all_paths is true, indexes all paths visible via for_each_path_handle().
-    /// If false, indexes only REFERENCE and GENERIC sense paths.
-    PackedReferencePathOverlay(const PathHandleGraph* graph, bool all_paths);
-    
     // We assume that tracing out a path is fast in the backing graph, but
     // finding visits on nodes is slow. We override the reverse lookups to go
     // from graph nodes to paths.
 
     /// overload this to use the cache 
     virtual path_handle_t get_path_handle_of_step(const step_handle_t& step_handle) const;
+
+    /// Override to filter paths to those that are indexed. 
+    bool has_path(const std::string& path_name) const;
+    
+    /// Override to filter paths to those that are indexed.
+    size_t get_path_count() const;
 
 protected:
 
@@ -60,7 +66,7 @@ protected:
 
     // PathHandleGraph interface
 
-    /// Override to filter paths based on all_paths flag.
+    /// Override to filter paths to those that are indexed. 
     bool for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const;
 
     /// Calls the given function for each step of the given handle on a path.

--- a/bdsg/include/bdsg/overlays/path_position_overlays.hpp
+++ b/bdsg/include/bdsg/overlays/path_position_overlays.hpp
@@ -26,13 +26,19 @@ using namespace handlegraph;
  * by augmenting it with relatively simple data structures.
  *
  * To also provide mutable methods, see MutablePositionOverlay below.
+ *
+ * Path position queries on unindexed paths will raise std::logic_error.
  */
 class PositionOverlay : public PathPositionHandleGraph, public ExpandingOverlayGraph {
         
 public:
     
-    /// Make a postion overlay on the graph. Indexes any hidden paths that
-    /// appear in extra_path_names.
+    /// Make a postion overlay on the graph. Indexes any REFERENCE and GENERIC
+    /// paths (or all paths if all_paths is set), as well as paths that appear
+    /// in extra_path_names.
+    PositionOverlay(PathHandleGraph* graph, bool all_paths, const std::unordered_set<std::string>& extra_path_names = {});
+    /// Make a postion overlay on the graph. Indexes any REFERENCE and GENERIC
+    /// paths, as well as paths that appear in extra_path_names.
     PositionOverlay(PathHandleGraph* graph, const std::unordered_set<std::string>& extra_path_names = {});
     PositionOverlay();
     ~PositionOverlay();
@@ -231,8 +237,9 @@ public:
 protected:
     
     /// Construct the index over path positions.
-    /// Always includes paths with names in the given set, even if they are hidden.
-    void index_path_positions(const std::unordered_set<std::string>& extra_path_names = {});
+    /// Indexes REFERENCE anf GENERIC sense paths by default, unless all_paths is true.
+    /// Always includes paths with names in the given set.
+    void index_path_positions(bool all_paths, const std::unordered_set<std::string>& extra_path_names = {});
     
     /// The graph we're overlaying
     PathHandleGraph* graph = nullptr;
@@ -267,11 +274,21 @@ class MutablePositionOverlay : public PositionOverlay, public MutablePathDeletab
 
     // TODO: Can we hack around this some other way?
     MutablePathDeletableHandleGraph* mutable_graph;
+
+    // We also need to remember the construction parameters for re-indexing
+    bool all_paths;
+    std::unordered_set<std::string> extra_path_names;
     
 public:
     
-    MutablePositionOverlay(MutablePathDeletableHandleGraph* graph);
-    MutablePositionOverlay();
+    /// Make a postion overlay on the graph. Indexes any REFERENCE and GENERIC
+    /// paths (or all paths if all_paths is set), as well as paths that appear
+    /// in extra_path_names.
+    MutablePositionOverlay(MutablePathDeletableHandleGraph* graph, bool all_paths, const std::unordered_set<std::string>& extra_path_names = {});
+    /// Make a postion overlay on the graph. Indexes any REFERENCE and GENERIC
+    /// paths, as well as paths that appear in extra_path_names.
+    MutablePositionOverlay(MutablePathDeletableHandleGraph* graph, const std::unordered_set<std::string>& extra_path_names = {});
+
     ~MutablePositionOverlay();
     
     ////////////////////////////////////////////////////////////////////////////

--- a/bdsg/include/bdsg/overlays/reference_path_overlay.hpp
+++ b/bdsg/include/bdsg/overlays/reference_path_overlay.hpp
@@ -35,14 +35,15 @@ public:
     
     /// Create a ReferencePathOverlay indexing paths in the backing graph.
     /// If all_paths is true, indexes all paths.
-    /// If false (default), indexes only REFERENCE and GENERIC sense paths.
-    /// For path names in extra_path_names, look them up and index them too.
-    ReferencePathOverlay(const PathHandleGraph* graph, bool all_paths = false);
+    /// If false (default), indexes only REFERENCE and GENERIC sense paths,
+    /// plus those listed in extra_path_names.
+    ReferencePathOverlay(const PathHandleGraph* graph, bool all_paths, const std::unordered_set<std::string>& extra_path_names = {});
 
-    /// Same, but also indexes hidden paths listed in extra_path_names.
-    ReferencePathOverlay(const PathHandleGraph* graph,
-                         const std::unordered_set<std::string>& extra_path_names,
-                         bool all_paths = false);
+    /// Create a ReferencePathOverlay indexing paths in the backing graph.
+    /// If all_paths is true, indexes all paths.
+    /// If false (default), indexes only REFERENCE and GENERIC sense paths.
+    ReferencePathOverlay(const PathHandleGraph* graph, const std::unordered_set<std::string>& extra_path_names = {});
+    
     ReferencePathOverlay() = default;
     ~ReferencePathOverlay() = default;
     

--- a/bdsg/include/bdsg/overlays/reference_path_overlay.hpp
+++ b/bdsg/include/bdsg/overlays/reference_path_overlay.hpp
@@ -27,26 +27,16 @@ using namespace handlegraph;
  * position queries on them. The original graph's handle_t's and path_handle_t's
  * remain valid for the overlay, but not the step_t's.
  *
- * Note that paths that are not indexed as reference paths (i.e. those that are
- * hidden from for_each_path_handle by the backing graph and not listed in
- * extra_path_names on construction) *will not be accessible through the
- * overlay*! You can ask if they exist, but trying to get handles to steps on
- * them will not work. To actually look at them you will need to go back to the
- * base graph.
- *
- * TODO: Make the overlay transparent so that paths that don't get indexed in
- * the overlay remain accessible but without the (fast versions of?) the
- * position queries.
+ * Note that paths that are not indexed *will not exist in the overlay*!
  */
 class ReferencePathOverlay : public PathPositionHandleGraph {
         
 public:
     
     /// Create a ReferencePathOverlay indexing paths in the backing graph.
-    /// If all_paths is true, indexes all paths visible via for_each_path_handle().
+    /// If all_paths is true, indexes all paths.
     /// If false (default), indexes only REFERENCE and GENERIC sense paths.
-    /// For path names in extra_path_names, look them up and index them too,
-    /// even if they are hidden.
+    /// For path names in extra_path_names, look them up and index them too.
     ReferencePathOverlay(const PathHandleGraph* graph, bool all_paths = false);
 
     /// Same, but also indexes hidden paths listed in extra_path_names.

--- a/bdsg/include/bdsg/snarl_distance_index.hpp
+++ b/bdsg/include/bdsg/snarl_distance_index.hpp
@@ -611,7 +611,7 @@ private:
 
 ////////////////////////////// How to interpret net_handle_ts
 //
-public:
+private:
 
     ///A record_t is the type of structure that a record can be.
     /// The actual distance index is stored as a series of "records" for each snarl/node/chain. 

--- a/bdsg/src/packed_path_position_overlay.cpp
+++ b/bdsg/src/packed_path_position_overlay.cpp
@@ -11,9 +11,13 @@ PackedPositionOverlay::PackedPositionOverlay(const PathHandleGraph* graph, size_
     // Nothing to do!
 }
 
-PackedPositionOverlay::PackedPositionOverlay(const PathHandleGraph* graph, const std::unordered_set<std::string>& extra_path_names, size_t steps_per_index) : PackedPositionOverlay(graph, steps_per_index) {
+PackedPositionOverlay::PackedPositionOverlay(const PathHandleGraph* graph, bool all_paths, const std::unordered_set<std::string>& extra_path_names, size_t steps_per_index) : PackedPositionOverlay(graph, steps_per_index) {
     // Actually build the index
-    index_path_positions(false, extra_path_names);
+    index_path_positions(all_paths, extra_path_names);
+}
+
+PackedPositionOverlay::PackedPositionOverlay(const PathHandleGraph* graph, const std::unordered_set<std::string>& extra_path_names, size_t steps_per_index): PackedPositionOverlay(graph, false, extra_path_names, steps_per_index) {
+    // Nothing to do!
 }
 
 bool PackedPositionOverlay::has_node(nid_t node_id) const {

--- a/bdsg/src/packed_path_position_overlay.cpp
+++ b/bdsg/src/packed_path_position_overlay.cpp
@@ -7,8 +7,13 @@
 
 namespace bdsg {
 
-PackedPositionOverlay::PackedPositionOverlay(const PathHandleGraph* graph, const std::unordered_set<std::string>& extra_path_names, size_t steps_per_index) : graph(graph), steps_per_index(steps_per_index) {
-    index_path_positions(extra_path_names);
+PackedPositionOverlay::PackedPositionOverlay(const PathHandleGraph* graph, size_t steps_per_index) : graph(graph), steps_per_index(steps_per_index) {
+    // Nothing to do!
+}
+
+PackedPositionOverlay::PackedPositionOverlay(const PathHandleGraph* graph, const std::unordered_set<std::string>& extra_path_names, size_t steps_per_index) : PackedPositionOverlay(graph, steps_per_index) {
+    // Actually build the index
+    index_path_positions(false, extra_path_names);
 }
 
 bool PackedPositionOverlay::has_node(nid_t node_id) const {
@@ -162,7 +167,13 @@ bool PackedPositionOverlay::for_each_step_of_sense_impl(const handle_t& visited,
 
 
 size_t PackedPositionOverlay::get_path_length(const path_handle_t& path_handle) const {
-    const auto& range = path_range.at(as_integer(path_handle));
+    auto found = path_range.find(as_integer(path_handle));
+    if (found == path_range.end()) {
+        // We're working on an un-indexed path
+        throw std::logic_error("Path " + graph->get_path_name(path_handle) + " is not indexed for " + std::string(__func__));
+    }
+
+    const auto& range = found->second;
     if (range.start == range.end) {
         return 0;
     }
@@ -178,7 +189,12 @@ size_t PackedPositionOverlay::get_position_of_step(const step_handle_t& step) co
         return get_path_length(path);
     }
     else {
-        auto& range = path_range.at(as_integer(path));
+        auto found = path_range.find(as_integer(path));
+        if (found == path_range.end()) {
+            // We're working on an un-indexed path
+            throw std::logic_error("Path " + graph->get_path_name(path) + " is not indexed for " + std::string(__func__));
+        }
+        auto& range = found->second;
         const boomphf::mphf<step_handle_t, StepHash>& const_step_hash = indexes[range.index_number].step_hash.back();
         // We can't use the lookup function on a const mphf, because it isn't
         // marked const. But it is thread safe and really ought to be const. So
@@ -191,7 +207,13 @@ size_t PackedPositionOverlay::get_position_of_step(const step_handle_t& step) co
 step_handle_t PackedPositionOverlay::get_step_at_position(const path_handle_t& path,
                                                           const size_t& position) const {
     
-    const auto& range = path_range.at(as_integer(path));
+    auto found = path_range.find(as_integer(path));
+    if (found == path_range.end()) {
+        // We're working on an un-indexed path
+        throw std::logic_error("Path " + graph->get_path_name(path) + " is not indexed for " + std::string(__func__));
+    }
+
+    const auto& range = found->second;
     
     // check if position it outside the range (handles edge case of an empty path too)
     if (position >= get_path_length(path)) {
@@ -222,21 +244,22 @@ handle_t PackedPositionOverlay::get_underlying_handle(const handle_t& handle) co
     return handle;
 }
 
-void PackedPositionOverlay::index_path_positions(const std::unordered_set<std::string>& extra_path_names) {
+void PackedPositionOverlay::index_path_positions(bool all_paths, const std::unordered_set<std::string>& extra_path_names) {
     
     // I'm not sure how to pass handles to OMP tasks by value, when we'd return
     // out of the functions that created the tasks and are holding the tasks'
     // locals. So first we'll collect all the path handles.
     // TODO: deduplicate with BBHashHelper's copy of all the path handles?
     std::vector<path_handle_t> path_handles;
-    for_each_path_handle([&](const path_handle_t& path_handle) {
+    std::unordered_set<PathSense> senses = {PathSense::REFERENCE, PathSense::GENERIC};
+    graph->for_each_path_matching(all_paths ? nullptr : &senses, nullptr, nullptr, [&](const path_handle_t& path_handle) {
         path_handles.push_back(path_handle);
     });
     if (!extra_path_names.empty()) {
         // Skip any named paths we already visited
         std::unordered_set<path_handle_t> seen(path_handles.begin(), path_handles.end());
         for (auto& name : extra_path_names) {
-            path_handle_t path = get_path_handle(name);
+            path_handle_t path = graph->get_path_handle(name);
             if (!seen.count(path)) {
                 // But remember to visit any we haven't yet.
                 path_handles.push_back(path);

--- a/bdsg/src/packed_reference_path_overlay.cpp
+++ b/bdsg/src/packed_reference_path_overlay.cpp
@@ -9,7 +9,7 @@
 
 namespace bdsg {
 
-PackedReferencePathOverlay::PackedReferencePathOverlay(const PathHandleGraph* graph, bool all_paths, const std::unordered_set<std::string>& extra_path_names, size_t steps_per_index) : PackedPositionOverlay(graph, steps_per_index), all_paths(all_paths) {
+PackedReferencePathOverlay::PackedReferencePathOverlay(const PathHandleGraph* graph, bool all_paths, const std::unordered_set<std::string>& extra_path_names, size_t steps_per_index) : PackedPositionOverlay(graph, steps_per_index) {
     // We can't just chain to the base class constructor with these arguments
     // because we need virtual methods in this class to be available before the
     // index build starts, so we can build the extra indexes we add in there.

--- a/bdsg/src/packed_reference_path_overlay.cpp
+++ b/bdsg/src/packed_reference_path_overlay.cpp
@@ -9,37 +9,50 @@
 
 namespace bdsg {
 
-PackedReferencePathOverlay::PackedReferencePathOverlay(const PathHandleGraph* graph, const std::unordered_set<std::string>& extra_path_names, size_t steps_per_index) : PackedPositionOverlay() {
+PackedReferencePathOverlay::PackedReferencePathOverlay(const PathHandleGraph* graph, bool all_paths, const std::unordered_set<std::string>& extra_path_names, size_t steps_per_index) : PackedPositionOverlay(graph, steps_per_index), all_paths(all_paths) {
     // We can't just chain to the base class constructor with these arguments
     // because we need virtual methods in this class to be available before the
-    // index build starts.
-    this->graph = graph;
-    this->steps_per_index = steps_per_index;
+    // index build starts, so we can build the extra indexes we add in there.
+    // See
+    // <https://isocpp.org/wiki/faq/strange-inheritance#calling-virtuals-from-ctors>.
 
     // Now do the index build
-    index_path_positions(extra_path_names);
+    index_path_positions(all_paths, extra_path_names);
 
     // initialize the index cache
     this->last_step_to_path_idx.resize(get_thread_count(), 0);
 }
 
-PackedReferencePathOverlay::PackedReferencePathOverlay(const PathHandleGraph* graph, bool all_paths)
-    : PackedPositionOverlay(), all_paths(all_paths) {
-    // Can't use delegating constructor because we need all_paths set before
-    // index_path_positions runs (it calls for_each_path_handle which uses our override).
-    this->graph = graph;
-    this->steps_per_index = 20000000;
-    index_path_positions();
-    this->last_step_to_path_idx.resize(get_thread_count(), 0);
+PackedReferencePathOverlay::PackedReferencePathOverlay(const PathHandleGraph* graph, const std::unordered_set<std::string>& extra_path_names, size_t steps_per_index) : PackedReferencePathOverlay(graph, false, extra_path_names, steps_per_index) {
+    // Nothing to do!
+}
+
+bool PackedReferencePathOverlay::has_path(const std::string& path_name) const {
+    if (!graph->has_path(path_name)) {
+        // Path is not in backing graph at all
+        return false;
+    }
+    path_handle_t path = graph->get_path_handle(path_name);
+    if (!path_range.count(as_integer(path))) {
+        // Path is not indexed, so say it doesn't exist.
+        return false;
+    }
+    return true;
+}
+
+size_t PackedReferencePathOverlay::get_path_count() const {
+    return path_range.size();
 }
 
 bool PackedReferencePathOverlay::for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const {
-    if (all_paths) {
-        return graph->for_each_path_handle(iteratee);
-    } else {
-        std::unordered_set<PathSense> senses = {PathSense::REFERENCE, PathSense::GENERIC};
-        return graph->for_each_path_matching(&senses, nullptr, nullptr, iteratee);
+    // Loop over the index keys, which are path handles.
+    // We assume indexing is done already.
+    for (auto& kv : path_range) {
+        if (!iteratee(as_path_handle(kv.first))) {
+            return false;
+        }
     }
+    return true;
 }
 
 path_handle_t PackedReferencePathOverlay::get_path_handle_of_step(const step_handle_t& step_handle) const {
@@ -66,8 +79,8 @@ path_handle_t PackedReferencePathOverlay::get_path_handle_of_step(const step_han
         idx_hint = index_num;
         return as_path_handle(visit_index.step_to_path.get(hash));
     }
-    // should never happen, but we fall back on the backing graph
-    return this->graph->get_path_handle_of_step(step_handle);
+    // If we can't find it, raise an error
+    throw std::runtime_error("Tried to get path handle of step not on any indexed path");
 }
 
 bool PackedReferencePathOverlay::for_each_step_on_handle_impl(const handle_t& handle,

--- a/bdsg/src/path_position_overlays.cpp
+++ b/bdsg/src/path_position_overlays.cpp
@@ -3,7 +3,7 @@
 namespace bdsg {
 
     PositionOverlay::PositionOverlay(PathHandleGraph* graph, const std::unordered_set<std::string>& extra_path_names) : graph(graph) {
-        index_path_positions(extra_path_names);
+        index_path_positions(false, extra_path_names);
     }
 
     PositionOverlay::PositionOverlay() {
@@ -164,7 +164,13 @@ namespace bdsg {
     }
     
     size_t PositionOverlay::get_path_length(const path_handle_t& path_handle) const {
-        const auto& path_step_by_position = step_by_position.at(path_handle);
+        auto found = step_by_position.find(path_handle);
+        if (found == step_by_position.end()) {
+            // This path is not indexed.
+            throw std::logic_error("Path " + get_graph()->get_path_name(path_handle) + " is not indexed for " + std::string(__func__));
+        }
+
+        const auto& path_step_by_position = found->second;
         auto last = path_step_by_position.rbegin();
         if (last == path_step_by_position.rend()) {
             return 0;
@@ -178,13 +184,27 @@ namespace bdsg {
     }
     
     size_t PositionOverlay::get_position_of_step(const step_handle_t& step) const {
-        return offset_by_step.at(step) - min_path_offset.at(get_path_handle_of_step(step));
+        path_handle_t path_handle = get_path_handle_of_step(step);
+        auto found = min_path_offset.find(path_handle);
+        if (found == min_path_offset.end()) {
+            // This path is not indexed.
+            throw std::logic_error("Path " + get_graph()->get_path_name(path_handle) + " is not indexed for " + std::string(__func__));
+        }
+
+        return offset_by_step.at(step) - found->second;
     }
     
     step_handle_t PositionOverlay::get_step_at_position(const path_handle_t& path,
                                                         const size_t& position) const {
         
-        int64_t lookup_position = position + min_path_offset.at(path);
+        auto found = min_path_offset.find(path);
+        if (found == min_path_offset.end()) {
+            // This path is not indexed.
+            throw std::logic_error("Path " + get_graph()->get_path_name(path) + " is not indexed for " + std::string(__func__));
+        }
+
+        // TODO: Why isn't this a subtraction?
+        int64_t lookup_position = position + found->second;
         
         const auto& path_step_by_position = step_by_position.at(path);
         if (path_step_by_position.empty()) {
@@ -205,7 +225,7 @@ namespace bdsg {
         return handle;
     }
     
-    void PositionOverlay::index_path_positions(const std::unordered_set<std::string>& extra_path_names) {
+    void PositionOverlay::index_path_positions(bool all_paths, const std::unordered_set<std::string>& extra_path_names) {
         
         auto visit_path = [&](const path_handle_t& path) {
             int64_t offset = 0;
@@ -217,8 +237,9 @@ namespace bdsg {
                 offset += get_graph()->get_length(get_graph()->get_handle_of_step(step));
             });
         };
-
-        get_graph()->for_each_path_handle(visit_path);
+        
+        std::unordered_set<PathSense> senses = {PathSense::REFERENCE, PathSense::GENERIC};
+        get_graph()->for_each_path_matching(all_paths ? nullptr : &senses, nullptr, nullptr, visit_path);
 
         for (auto& name : extra_path_names) {
             path_handle_t path = get_graph()->get_path_handle(name);
@@ -229,16 +250,22 @@ namespace bdsg {
         }
     }
     
-    MutablePositionOverlay::MutablePositionOverlay(MutablePathDeletableHandleGraph* graph) : PositionOverlay(graph), mutable_graph(graph) {
-        
+    MutablePositionOverlay::MutablePositionOverlay(MutablePathDeletableHandleGraph* graph, bool all_paths, const std::unordered_set<std::string>& extra_path_names) 
+        : PositionOverlay(graph),
+          mutable_graph(graph),
+          all_paths(all_paths),
+          extra_path_names(extra_path_names)
+    {
+        // Nothing to do!
     }
-    
-    MutablePositionOverlay::MutablePositionOverlay() {
+    MutablePositionOverlay::MutablePositionOverlay(MutablePathDeletableHandleGraph* graph, const std::unordered_set<std::string>& extra_path_names)
+        : MutablePositionOverlay(graph, false, extra_path_names) {
         
+        // Nothing to do!
     }
     
     MutablePositionOverlay::~MutablePositionOverlay() {
-        
+        // Nothing to do!
     }
     
     handle_t MutablePositionOverlay::create_handle(const std::string& sequence) {
@@ -347,24 +374,36 @@ namespace bdsg {
     
     path_handle_t MutablePositionOverlay::create_path_handle(const string& name, bool is_circular) {
         path_handle_t path_handle = get_graph()->create_path_handle(name, is_circular);
+        // New paths are always indexed (until we reindex).
         min_path_offset[path_handle] = 0;
         step_by_position[path_handle] = map<int64_t, step_handle_t>();
+        // Remember we want to re-index this one if we reindex
+        extra_path_names.insert(get_path_name(path_handle));
         return path_handle;
     }
     
     step_handle_t MutablePositionOverlay::append_step(const path_handle_t& path, const handle_t& to_append) {
-        int64_t position = get_path_length(path) + min_path_offset[path];
         step_handle_t step = get_graph()->append_step(path, to_append);
-        step_by_position[path][position] = step;
-        offset_by_step[step] = position;
+
+        auto found = min_path_offset.find(path);
+        if (found != min_path_offset.end()) {
+            // Update the index if the path is indexed
+            int64_t position = get_path_length(path) + found->second;
+            step_by_position[path][position] = step;
+            offset_by_step[step] = position;
+        }
         return step;
     }
     
     step_handle_t MutablePositionOverlay::prepend_step(const path_handle_t& path, const handle_t& to_prepend) {
-        min_path_offset[path] -= get_length(to_prepend);
         step_handle_t step = get_graph()->prepend_step(path, to_prepend);
-        offset_by_step[step] = min_path_offset[path];
-        step_by_position[path][min_path_offset[path]] = step;
+        
+        auto found = min_path_offset.find(path);
+        if (found != min_path_offset.end()) {
+            found->second -= get_length(to_prepend);
+            offset_by_step[step] = found->second;
+            step_by_position[path][found->second] = step;
+        }
         return step;
     }
     
@@ -372,24 +411,38 @@ namespace bdsg {
                                                                                const step_handle_t& segment_end,
                                                                                const vector<handle_t>& new_segment) {
         
-        // TODO: there really is no way to do this efficiently since it can shift the offsets downstream...
         
-        int64_t offset = offset_by_step[segment_begin];
-        
-        // erase the records of all steps from the beginning of the segment onwards
-        auto& path_step_by_position = step_by_position[get_path_handle_of_step(segment_begin)];
-        path_step_by_position.erase(path_step_by_position.find(offset), path_step_by_position.end());
-        for (auto step = segment_begin; step != path_end(get_path_handle_of_step(segment_begin)); step = get_next_step(step)) {
-            offset_by_step.erase(step);
+        path_handle_t path = get_path_handle_of_step(segment_begin);
+        auto found = step_by_position.find(path);
+        int64_t offset;
+        if (found != step_by_position.end()) {
+            // This path is indexed, so update the index
+
+            // TODO: there really is no way to do this efficiently since it can shift the offsets downstream...
+            
+            offset = offset_by_step[segment_begin];
+            
+            // erase the records of all steps from the beginning of the segment onwards
+            auto& path_step_by_position = found->second;
+            path_step_by_position.erase(path_step_by_position.find(offset), path_step_by_position.end());
+            for (auto step = segment_begin; step != path_end(path); step = get_next_step(step)) {
+                offset_by_step.erase(step);
+            }
         }
-        
+
+        // Do the rewrite and invalidate/replace steps
         auto new_range = get_graph()->rewrite_segment(segment_begin, segment_end, new_segment);
-        
-        // reindex the new suffix of the path
-        for (auto step = new_range.first; step != path_end(get_path_handle_of_step(new_range.first)); step = get_next_step(step)) {
-            offset_by_step[step] = offset;
-            path_step_by_position[offset] = step;
-            offset += get_length(get_handle_of_step(step));
+
+        if (found != step_by_position.end()) {
+
+            auto& path_step_by_position = found->second;
+            
+            // reindex the new suffix of the path
+            for (auto step = new_range.first; step != path_end(path); step = get_next_step(step)) {
+                offset_by_step[step] = offset;
+                path_step_by_position[offset] = step;
+                offset += get_length(get_handle_of_step(step));
+            }
         }
         
         return new_range;
@@ -405,48 +458,54 @@ namespace bdsg {
         step_by_position.clear();
         offset_by_step.clear();
         min_path_offset.clear();
-        index_path_positions();
+        index_path_positions(this->all_paths, this->extra_path_names);
     }
     
     void MutablePositionOverlay::reindex_contiguous_segment(const step_handle_t& step) {
         
-        // we may have already re-annotated this occurrence starting from a different step
-        if (offset_by_step.count(step)) {
-            return;
-        }
-        
-        // walk backwards until the beginning of the path or a step that still has its
-        // position recorded
-        auto walker = step;
-        while (!offset_by_step.count(walker)
-               && walker != path_begin(get_path_handle_of_step(step))) {
-            walker = get_previous_step(walker);
-        }
-        
-        // compute the position of the next step without an offset annotation
-        int64_t position;
-        if (offset_by_step.count(walker)) {
-            position = (min_path_offset[get_path_handle_of_step(step)]
-                        + offset_by_step[walker]
-                        + get_length(get_handle_of_step(walker)));
-            // point the walker at the next unindexed position
-            walker = get_next_step(walker);
-        }
-        else {
-            // we must have have hit path_begin to have exited the previous while loop
-            position = min_path_offset[get_path_handle_of_step(step)];
-        }
-        
-        // add position annotations for all of the new handles (can also soak up adjacent
-        // occurrences of the same node on this path)
-        auto& path_step_by_position = step_by_position[get_path_handle_of_step(step)];
-        for (; walker != path_end(get_path_handle_of_step(step)) && !offset_by_step.count(walker);
-             walker = get_next_step(walker)) {
+        path_handle_t path = get_path_handle_of_step(step);
+        auto found = min_path_offset.find(path);
+        if (found != min_path_offset.end()) {
+            // The path is indexed, so update the index
+
+            // we may have already re-annotated this occurrence starting from a different step
+            if (offset_by_step.count(step)) {
+                return;
+            }
             
-            path_step_by_position[position] = walker;
-            offset_by_step[walker] = position;
+            // walk backwards until the beginning of the path or a step that still has its
+            // position recorded
+            auto walker = step;
+            while (!offset_by_step.count(walker)
+                   && walker != path_begin(path)) {
+                walker = get_previous_step(walker);
+            }
             
-            position += get_length(get_handle_of_step(walker));
+            // compute the position of the next step without an offset annotation
+            int64_t position;
+            if (offset_by_step.count(walker)) {
+                position = (found->second
+                            + offset_by_step[walker]
+                            + get_length(get_handle_of_step(walker)));
+                // point the walker at the next unindexed position
+                walker = get_next_step(walker);
+            }
+            else {
+                // we must have have hit path_begin to have exited the previous while loop
+                position = found->second;
+            }
+            
+            // add position annotations for all of the new handles (can also soak up adjacent
+            // occurrences of the same node on this path)
+            auto& path_step_by_position = step_by_position[path];
+            for (; walker != path_end(path) && !offset_by_step.count(walker);
+                 walker = get_next_step(walker)) {
+                
+                path_step_by_position[position] = walker;
+                offset_by_step[walker] = position;
+                
+                position += get_length(get_handle_of_step(walker));
+            }
         }
     }
     

--- a/bdsg/src/reference_path_overlay.cpp
+++ b/bdsg/src/reference_path_overlay.cpp
@@ -13,13 +13,10 @@ namespace bdsg {
 using namespace std;
 using namespace handlegraph;
 
-ReferencePathOverlay::ReferencePathOverlay(const PathHandleGraph* graph, bool all_paths)
-    : ReferencePathOverlay(graph, std::unordered_set<std::string>{}, all_paths) {
-}
-
 ReferencePathOverlay::ReferencePathOverlay(const PathHandleGraph* graph,
-                                           const std::unordered_set<std::string>& extra_path_names,
-                                           bool all_paths) : graph(graph) {
+                                           bool all_paths,
+                                           const std::unordered_set<std::string>& extra_path_names)
+    : graph(graph) {
 
     std::unordered_map<path_handle_t, size_t> cached_step_counts;
 
@@ -326,6 +323,12 @@ ReferencePathOverlay::ReferencePathOverlay(const PathHandleGraph* graph,
     for (auto& worker : workers) {
         worker.join();
     }
+}
+
+ReferencePathOverlay::ReferencePathOverlay(const PathHandleGraph* graph, const std::unordered_set<std::string>& extra_path_names)
+    : ReferencePathOverlay(graph, false, extra_path_names) {
+
+    // Nothing to do!
 }
 
 bool ReferencePathOverlay::has_node(nid_t node_id) const {

--- a/bdsg/src/reference_path_overlay.cpp
+++ b/bdsg/src/reference_path_overlay.cpp
@@ -397,7 +397,15 @@ size_t ReferencePathOverlay::get_path_count() const {
 }
 
 bool ReferencePathOverlay::has_path(const std::string& path_name) const {
-    return graph->has_path(path_name);
+    if (!graph->has_path(path_name)) {
+        return false;
+    }
+    path_handle_t path = graph->get_path_handle(path_name);
+    if (!reference_paths.count(path)) {
+        // Path was in base graph but was not indexed
+        return false;
+    }
+    return true;
 }
 
 path_handle_t ReferencePathOverlay::get_path_handle(const std::string& path_name) const {

--- a/bdsg/src/test_libbdsg.cpp
+++ b/bdsg/src/test_libbdsg.cpp
@@ -4080,7 +4080,13 @@ void test_path_position_overlays() {
         step_handle_t s1 = graph.append_step(p1, h1);
         step_handle_t s2 = graph.append_step(p1, h2);
         step_handle_t s3 = graph.append_step(p1, h4);
-        
+
+        path_handle_t p2 = graph.create_path(PathSense::HAPLOTYPE, "somebody", "chr1", 1, 0, PathMetadata::NO_SUBRANGE);
+        step_handle_t p2s1 = graph.append_step(p2, h1);
+        step_handle_t p2s2 = graph.append_step(p2, h2);
+        step_handle_t p2s3 = graph.append_step(p2, h4);
+        std::string p2_name = graph.get_path_name(p2);
+
         // static position overlays
         {
             vector<PathPositionHandleGraph*> overlays;
@@ -4094,6 +4100,7 @@ void test_path_position_overlays() {
             for (PathPositionHandleGraph* implementation : overlays) {
                 PathPositionHandleGraph& overlay = *implementation;
                 
+                // Generic path should be indexed
                 assert(overlay.get_path_length(p1) == 9);
                 
                 assert(overlay.get_position_of_step(s1) == 0);
@@ -4112,6 +4119,16 @@ void test_path_position_overlays() {
                 assert(overlay.get_step_at_position(p1, 9) == overlay.path_end(p1));
                 assert(overlay.get_step_at_position(p1, 10) == overlay.path_end(p1));
                 assert(overlay.get_step_at_position(p1, 1000) == overlay.path_end(p1));
+                
+                // Haplotype path should not be indexed, but should exist
+                assert(overlay.has_path(p2_name));
+                assert(overlay.get_path_handle(p2_name) == p2);
+                try {
+                    overlay.get_path_length(p2);
+                    assert(false);
+                } catch(const std::logic_error& e) {
+                    // This is the exception we promise.
+                }
             }
         }
         
@@ -4252,11 +4269,18 @@ void test_packed_reference_path_overlay() {
         step_handle_t s2_1 = graph.append_step(p2, graph.flip(h4));
         step_handle_t s2_2 = graph.append_step(p2, graph.flip(h3));
         step_handle_t s2_3 = graph.append_step(p2, graph.flip(h1));
+
+        path_handle_t p3 = graph.create_path(PathSense::HAPLOTYPE, "somebody", "chr1", 1, 0, PathMetadata::NO_SUBRANGE);
+        step_handle_t p3s1 = graph.append_step(p3, h1);
+        step_handle_t p3s2 = graph.append_step(p3, h2);
+        step_handle_t p3s3 = graph.append_step(p3, h4);
+        std::string p3_name = graph.get_path_name(p3);
         
         {
         
             PackedReferencePathOverlay overlay(&graph);
-                
+            
+            // Generic paths should be indexed
             assert(overlay.get_path_length(p1) == 9);
             
             assert(overlay.get_position_of_step(s1) == 0);
@@ -4275,6 +4299,9 @@ void test_packed_reference_path_overlay() {
             assert(overlay.get_step_at_position(p1, 9) == overlay.path_end(p1));
             assert(overlay.get_step_at_position(p1, 10) == overlay.path_end(p1));
             assert(overlay.get_step_at_position(p1, 1000) == overlay.path_end(p1));
+
+            // Haplotype path should not exist in the overlay
+            assert(!overlay.has_path(p3_name));
             
             bool found1 = false;
             bool found2 = false;
@@ -4382,10 +4409,17 @@ void test_reference_path_overlay() {
         auto s1 = graph.append_step(p, h1);
         auto s2 = graph.append_step(p, h2);
         auto s3 = graph.append_step(p, h4);
+
+        path_handle_t p2 = graph.create_path(PathSense::HAPLOTYPE, "somebody", "chr1", 1, 0, PathMetadata::NO_SUBRANGE);
+        step_handle_t p2s1 = graph.append_step(p2, h1);
+        step_handle_t p2s2 = graph.append_step(p2, h2);
+        step_handle_t p2s3 = graph.append_step(p2, h4);
+        std::string p2_name = graph.get_path_name(p2);
         
         {
             ReferencePathOverlay ref_overlay(&graph);
             
+            // Generic path should be indexed
             auto os1 = ref_overlay.path_begin(p);
             auto os2 = ref_overlay.get_next_step(os1);
             auto os3 = ref_overlay.get_next_step(os2);
@@ -4415,6 +4449,9 @@ void test_reference_path_overlay() {
             assert(ref_overlay.get_position_of_step(os1) == 0);
             assert(ref_overlay.get_position_of_step(os2) == 4);
             assert(ref_overlay.get_position_of_step(os3) == 6);
+
+            // Haplotype path should not exist in the overlay
+            assert(!ref_overlay.has_path(p2_name));
             
             for (size_t i = 0; i < 25; ++i) {
                 if (i < 4) {

--- a/make_and_run_binder.py
+++ b/make_and_run_binder.py
@@ -35,7 +35,7 @@ def clone_repos():
         parent = os.getcwd()
         os.chdir('binder')
         # See also: Binder commit defined in CMakeLists.txt for header files.
-        subprocess.check_call(['git', 'checkout', '46ec0e88137d368eeedafecfa123004f8ad028d1'])
+        subprocess.check_call(['git', 'checkout', '93efb505172ce0ef34faa1f69a8e8f2b7455ce18'])
         os.chdir(parent)
     if not glob.glob("binder/build/pybind11"):
         print("pybind11 not found, cloning repo...")
@@ -69,7 +69,7 @@ def build_binder():
             '--pybind11',
             os.path.join(os.getcwd(), 'build/pybind11'),
             '--llvm-version',
-            '14.0.5'
+            '19.1.7'
         ]
         subprocess.check_call(build_command)
     return "binder/" + glob.glob('./build/*/*/bin/')[0] + "binder"
@@ -234,6 +234,9 @@ def make_bindings_code(all_includes_fn, binder_executable):
     # proj_include = " -I".join(proj_include)
     proj_include = [f'-I{i}' for i in proj_include]
     
+    
+    # See also: standard in CMakeLists.txt
+    # See also: standard in Makefile
     command = [binder_executable,
         "--root-module", python_module_name,
         "--prefix", f'{bindings_dir}/',
@@ -241,7 +244,7 @@ def make_bindings_code(all_includes_fn, binder_executable):
         "--config", "config.cfg",
         all_includes_fn,
         "--",
-        "-std=c++14",
+        "-std=c++17",
         f'-I{this_project_include}']
     if platform.system() == 'Darwin':
         # We need the MacOS SDK, which provides the C standard library and also a C++ STL, at least as of Apple Clang 14.


### PR DESCRIPTION
This makes `PositionOverlay`, `MutablePositionOverlay`, `ReferencePathOverlay`, `PackedPositionOverlay`, and `PackedReferencePathOverlay` work more similarly.

Now they all look at REFERENCE and GENERIC-sense paths by default, and can be told to look at other paths in a similar way.

Some of them completely hide the un-indexed paths, and others raise exceptions when trying to do operations on paths that would need the index when they aren't indexed, but both of those behaviors are now under test.

This is related to #236 and #237.